### PR TITLE
STR-2: add domain model records, sealed types, and value objects

### DIFF
--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/BroadcastResult.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/BroadcastResult.java
@@ -1,0 +1,21 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record BroadcastResult(
+        String txHash,
+        String chain,
+        Instant broadcastedAt,
+        Map<String, String> details) {
+
+    public BroadcastResult {
+        Objects.requireNonNull(txHash);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(broadcastedAt);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/CancelRequest.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/CancelRequest.java
@@ -1,0 +1,17 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record CancelRequest(
+        String requestedBy,
+        String reason,
+        Instant requestedAt) {
+
+    public CancelRequest {
+        Objects.requireNonNull(requestedBy);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/ConfirmationStatus.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/ConfirmationStatus.java
@@ -1,0 +1,19 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record ConfirmationStatus(
+        String txHash,
+        String chain,
+        long confirmations,
+        long requiredConfirmations,
+        boolean finalized) {
+
+    public ConfirmationStatus {
+        Objects.requireNonNull(txHash);
+        Objects.requireNonNull(chain);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/EscalationPolicy.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/EscalationPolicy.java
@@ -1,0 +1,15 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.List;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record EscalationPolicy(
+        List<EscalationTier> tiers) {
+
+    public EscalationPolicy {
+        Objects.requireNonNull(tiers);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/EscalationTier.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/EscalationTier.java
@@ -1,0 +1,21 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record EscalationTier(
+        int level,
+        Duration stuckThreshold,
+        BigDecimal gasMultiplier,
+        boolean requiresHumanApproval,
+        String description) {
+
+    public EscalationTier {
+        Objects.requireNonNull(stuckThreshold);
+        Objects.requireNonNull(gasMultiplier);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/EvmSubmissionResource.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/EvmSubmissionResource.java
@@ -1,0 +1,19 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record EvmSubmissionResource(
+        String chain,
+        String fromAddress,
+        long nonce,
+        AddressTier tier) implements SubmissionResource {
+
+    public EvmSubmissionResource {
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(fromAddress);
+        Objects.requireNonNull(tier);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/FeeEstimate.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/FeeEstimate.java
@@ -1,0 +1,24 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.util.Map;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record FeeEstimate(
+        BigDecimal maxFeePerGas,
+        BigDecimal maxPriorityFeePerGas,
+        BigDecimal computeUnitPrice,
+        BigDecimal estimatedCost,
+        String denomination,
+        FeeUrgency urgency,
+        Map<String, String> details) {
+
+    public FeeEstimate {
+        Objects.requireNonNull(estimatedCost);
+        Objects.requireNonNull(denomination);
+        Objects.requireNonNull(urgency);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/GasBudgetPolicy.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/GasBudgetPolicy.java
@@ -1,0 +1,24 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record GasBudgetPolicy(
+        BigDecimal percentage,
+        BigDecimal absoluteMinUsd,
+        BigDecimal absoluteMaxUsd) {
+
+    public GasBudgetPolicy {
+        Objects.requireNonNull(percentage);
+        Objects.requireNonNull(absoluteMinUsd);
+        Objects.requireNonNull(absoluteMaxUsd);
+    }
+
+    public BigDecimal calculateBudget(BigDecimal txValueUsd) {
+        var percentBudget = txValueUsd.multiply(percentage);
+        return percentBudget.max(absoluteMinUsd).min(absoluteMaxUsd);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/HumanApproval.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/HumanApproval.java
@@ -1,0 +1,19 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record HumanApproval(
+        ApprovalAction action,
+        String approvedBy,
+        String reason,
+        Instant approvedAt) {
+
+    public HumanApproval {
+        Objects.requireNonNull(action);
+        Objects.requireNonNull(approvedBy);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/NonceAllocation.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/NonceAllocation.java
@@ -1,0 +1,17 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record NonceAllocation(
+        String address,
+        String chain,
+        long nonce) {
+
+    public NonceAllocation {
+        Objects.requireNonNull(address);
+        Objects.requireNonNull(chain);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/PooledAddress.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/PooledAddress.java
@@ -1,0 +1,27 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record PooledAddress(
+        String address,
+        String chain,
+        ChainFamily chainFamily,
+        AddressTier tier,
+        AddressStatus status,
+        long currentNonce,
+        int inFlightCount,
+        String signerEndpoint,
+        Instant registeredAt) {
+
+    public PooledAddress {
+        Objects.requireNonNull(address);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(chainFamily);
+        Objects.requireNonNull(tier);
+        Objects.requireNonNull(status);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/RecoveryAttempt.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/RecoveryAttempt.java
@@ -1,0 +1,25 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record RecoveryAttempt(
+        int attemptNumber,
+        RecoveryAction action,
+        String originalTxHash,
+        String replacementTxHash,
+        FeeEstimate feeUsed,
+        BigDecimal gasCost,
+        Instant attemptedAt,
+        RecoveryOutcome outcome) {
+
+    public RecoveryAttempt {
+        Objects.requireNonNull(action);
+        Objects.requireNonNull(originalTxHash);
+        Objects.requireNonNull(outcome);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/RecoveryPlan.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/RecoveryPlan.java
@@ -1,0 +1,42 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.time.Duration;
+import java.util.Objects;
+
+import lombok.Builder;
+
+public sealed interface RecoveryPlan {
+
+    @Builder
+    record SpeedUp(String originalTxHash, FeeEstimate newFee) implements RecoveryPlan {
+
+        public SpeedUp {
+            Objects.requireNonNull(originalTxHash);
+            Objects.requireNonNull(newFee);
+        }
+    }
+
+    @Builder
+    record Cancel(String originalTxHash) implements RecoveryPlan {
+
+        public Cancel {
+            Objects.requireNonNull(originalTxHash);
+        }
+    }
+
+    @Builder
+    record Resubmit(String originalTxHash) implements RecoveryPlan {
+
+        public Resubmit {
+            Objects.requireNonNull(originalTxHash);
+        }
+    }
+
+    @Builder
+    record Wait(Duration estimatedClearance, String reason) implements RecoveryPlan {
+
+        public Wait {
+            Objects.requireNonNull(reason);
+        }
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/RecoveryResult.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/RecoveryResult.java
@@ -1,0 +1,18 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record RecoveryResult(
+        RecoveryOutcome outcome,
+        String replacementTxHash,
+        BigDecimal gasCost,
+        String details) {
+
+    public RecoveryResult {
+        Objects.requireNonNull(outcome);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SignedTransaction.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SignedTransaction.java
@@ -1,0 +1,20 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record SignedTransaction(
+        String intentId,
+        String chain,
+        byte[] signedPayload,
+        String signerAddress) {
+
+    public SignedTransaction {
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(signedPayload);
+        Objects.requireNonNull(signerAddress);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SolanaNonceAccount.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SolanaNonceAccount.java
@@ -1,0 +1,20 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record SolanaNonceAccount(
+        String nonceAccountAddress,
+        String authorityAddress,
+        String nonceValue,
+        NonceAccountStatus status) {
+
+    public SolanaNonceAccount {
+        Objects.requireNonNull(nonceAccountAddress);
+        Objects.requireNonNull(authorityAddress);
+        Objects.requireNonNull(nonceValue);
+        Objects.requireNonNull(status);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SolanaSubmissionResource.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SolanaSubmissionResource.java
@@ -1,0 +1,20 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record SolanaSubmissionResource(
+        String chain,
+        String fromAddress,
+        String nonceAccountAddress,
+        String nonceValue) implements SubmissionResource {
+
+    public SolanaSubmissionResource {
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(fromAddress);
+        Objects.requireNonNull(nonceAccountAddress);
+        Objects.requireNonNull(nonceValue);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/StuckAssessment.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/StuckAssessment.java
@@ -1,0 +1,19 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record StuckAssessment(
+        StuckReason reason,
+        StuckSeverity severity,
+        RecoveryPlan recommendedPlan,
+        String explanation) {
+
+    public StuckAssessment {
+        Objects.requireNonNull(reason);
+        Objects.requireNonNull(severity);
+        Objects.requireNonNull(recommendedPlan);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SubmissionResource.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SubmissionResource.java
@@ -1,0 +1,9 @@
+package com.stablebridge.txrecovery.domain.model;
+
+public sealed interface SubmissionResource
+        permits EvmSubmissionResource, SolanaSubmissionResource {
+
+    String chain();
+
+    String fromAddress();
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SubmittedTransaction.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/SubmittedTransaction.java
@@ -1,0 +1,35 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder(toBuilder = true)
+public record SubmittedTransaction(
+        String transactionId,
+        String intentId,
+        String chain,
+        String txHash,
+        String fromAddress,
+        SubmissionResource resource,
+        TransactionStatus status,
+        int retryCount,
+        BigDecimal gasSpent,
+        String gasDenomination,
+        BigDecimal gasBudget,
+        EscalationTier currentTier,
+        List<RecoveryAttempt> recoveryHistory,
+        Instant submittedAt,
+        Instant stuckSince,
+        Instant confirmedAt) {
+
+    public SubmittedTransaction {
+        Objects.requireNonNull(transactionId);
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(status);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionFilters.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionFilters.java
@@ -1,0 +1,15 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.time.Instant;
+
+import lombok.Builder;
+
+@Builder
+public record TransactionFilters(
+        String chain,
+        TransactionStatus status,
+        String fromAddress,
+        String toAddress,
+        Instant fromDate,
+        Instant toDate) {
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionIntent.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionIntent.java
@@ -1,0 +1,33 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record TransactionIntent(
+        String intentId,
+        String chain,
+        String toAddress,
+        BigDecimal amount,
+        String token,
+        int tokenDecimals,
+        BigInteger rawAmount,
+        String tokenContractAddress,
+        SubmissionStrategy strategy,
+        Map<String, String> metadata,
+        String batchId,
+        Instant createdAt) {
+
+    public TransactionIntent {
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(toAddress);
+        Objects.requireNonNull(amount);
+        Objects.requireNonNull(token);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionProjection.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionProjection.java
@@ -1,0 +1,31 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record TransactionProjection(
+        String transactionId,
+        String intentId,
+        String chain,
+        TransactionStatus status,
+        String txHash,
+        String fromAddress,
+        String toAddress,
+        BigDecimal amount,
+        String token,
+        int retryCount,
+        BigDecimal gasSpent,
+        Instant submittedAt,
+        Instant confirmedAt) {
+
+    public TransactionProjection {
+        Objects.requireNonNull(transactionId);
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(status);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionResult.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionResult.java
@@ -1,0 +1,25 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record TransactionResult(
+        String transactionId,
+        String intentId,
+        TransactionStatus finalStatus,
+        String txHash,
+        BigDecimal totalGasSpent,
+        String gasDenomination,
+        int totalAttempts,
+        Instant completedAt) {
+
+    public TransactionResult {
+        Objects.requireNonNull(transactionId);
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(finalStatus);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionSnapshot.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/TransactionSnapshot.java
@@ -1,0 +1,25 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record TransactionSnapshot(
+        String transactionId,
+        String intentId,
+        TransactionStatus status,
+        String txHash,
+        int retryCount,
+        BigDecimal gasSpent,
+        EscalationTier currentTier,
+        Instant updatedAt) {
+
+    public TransactionSnapshot {
+        Objects.requireNonNull(transactionId);
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(status);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/UnsignedTransaction.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/model/UnsignedTransaction.java
@@ -1,0 +1,24 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import java.util.Map;
+import java.util.Objects;
+
+import lombok.Builder;
+
+@Builder
+public record UnsignedTransaction(
+        String intentId,
+        String chain,
+        String fromAddress,
+        String toAddress,
+        byte[] payload,
+        Map<String, String> metadata) {
+
+    public UnsignedTransaction {
+        Objects.requireNonNull(intentId);
+        Objects.requireNonNull(chain);
+        Objects.requireNonNull(fromAddress);
+        Objects.requireNonNull(toAddress);
+        Objects.requireNonNull(payload);
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/GasBudgetPolicyTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/GasBudgetPolicyTest.java
@@ -1,0 +1,110 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+
+class GasBudgetPolicyTest {
+
+    private final GasBudgetPolicy policy = GasBudgetPolicy.builder()
+            .percentage(new BigDecimal("0.01"))
+            .absoluteMinUsd(new BigDecimal("5"))
+            .absoluteMaxUsd(new BigDecimal("500"))
+            .build();
+
+    @Test
+    void shouldReturnAbsoluteMinUsd_whenPercentageBudgetBelowFloor() {
+        // given
+        var txValueUsd = new BigDecimal("100");
+
+        // when
+        var budget = policy.calculateBudget(txValueUsd);
+
+        // then — $100 * 1% = $1, below min $5, returns $5
+        assertThat(budget).isEqualByComparingTo(new BigDecimal("5"));
+    }
+
+    @Test
+    void shouldReturnPercentageBudget_whenBetweenMinAndMax() {
+        // given
+        var txValueUsd = new BigDecimal("10000");
+
+        // when
+        var budget = policy.calculateBudget(txValueUsd);
+
+        // then — $10,000 * 1% = $100, between $5 and $500, returns $100
+        assertThat(budget).isEqualByComparingTo(new BigDecimal("100"));
+    }
+
+    @Test
+    void shouldReturnAbsoluteMaxUsd_whenPercentageBudgetAboveCeiling() {
+        // given
+        var txValueUsd = new BigDecimal("100000");
+
+        // when
+        var budget = policy.calculateBudget(txValueUsd);
+
+        // then — $100,000 * 1% = $1,000, above max $500, returns $500
+        assertThat(budget).isEqualByComparingTo(new BigDecimal("500"));
+    }
+
+    @Test
+    void shouldReturnExactMin_whenPercentageBudgetEqualsMin() {
+        // given
+        var txValueUsd = new BigDecimal("500");
+
+        // when
+        var budget = policy.calculateBudget(txValueUsd);
+
+        // then — $500 * 1% = $5, equals min $5, returns $5
+        assertThat(budget).isEqualByComparingTo(new BigDecimal("5"));
+    }
+
+    @Test
+    void shouldReturnExactMax_whenPercentageBudgetEqualsMax() {
+        // given
+        var txValueUsd = new BigDecimal("50000");
+
+        // when
+        var budget = policy.calculateBudget(txValueUsd);
+
+        // then — $50,000 * 1% = $500, equals max $500, returns $500
+        assertThat(budget).isEqualByComparingTo(new BigDecimal("500"));
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenPercentageIsNull() {
+        // when / then
+        assertThatThrownBy(() -> GasBudgetPolicy.builder()
+                .percentage(null)
+                .absoluteMinUsd(new BigDecimal("5"))
+                .absoluteMaxUsd(new BigDecimal("500"))
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenAbsoluteMinUsdIsNull() {
+        // when / then
+        assertThatThrownBy(() -> GasBudgetPolicy.builder()
+                .percentage(new BigDecimal("0.01"))
+                .absoluteMinUsd(null)
+                .absoluteMaxUsd(new BigDecimal("500"))
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenAbsoluteMaxUsdIsNull() {
+        // when / then
+        assertThatThrownBy(() -> GasBudgetPolicy.builder()
+                .percentage(new BigDecimal("0.01"))
+                .absoluteMinUsd(new BigDecimal("5"))
+                .absoluteMaxUsd(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/RecoveryPlanTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/RecoveryPlanTest.java
@@ -1,0 +1,176 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.Duration;
+
+import org.junit.jupiter.api.Test;
+
+class RecoveryPlanTest {
+
+    @Test
+    void shouldCreateSpeedUpPlan() {
+        // given
+        var fee = FeeEstimate.builder()
+                .estimatedCost(new BigDecimal("0.005"))
+                .denomination("ETH")
+                .urgency(FeeUrgency.FAST)
+                .build();
+
+        // when
+        var plan = RecoveryPlan.SpeedUp.builder()
+                .originalTxHash("0xabc123")
+                .newFee(fee)
+                .build();
+
+        // then
+        assertThat(plan).isInstanceOf(RecoveryPlan.class);
+        assertThat(plan.originalTxHash()).isEqualTo("0xabc123");
+        assertThat(plan.newFee()).isEqualTo(fee);
+    }
+
+    @Test
+    void shouldCreateCancelPlan() {
+        // when
+        var plan = RecoveryPlan.Cancel.builder()
+                .originalTxHash("0xdef456")
+                .build();
+
+        // then
+        assertThat(plan).isInstanceOf(RecoveryPlan.class);
+        assertThat(plan.originalTxHash()).isEqualTo("0xdef456");
+    }
+
+    @Test
+    void shouldCreateResubmitPlan() {
+        // when
+        var plan = RecoveryPlan.Resubmit.builder()
+                .originalTxHash("0xghi789")
+                .build();
+
+        // then
+        assertThat(plan).isInstanceOf(RecoveryPlan.class);
+        assertThat(plan.originalTxHash()).isEqualTo("0xghi789");
+    }
+
+    @Test
+    void shouldCreateWaitPlan() {
+        // when
+        var plan = RecoveryPlan.Wait.builder()
+                .estimatedClearance(Duration.ofMinutes(5))
+                .reason("Mempool congestion expected to clear")
+                .build();
+
+        // then
+        assertThat(plan).isInstanceOf(RecoveryPlan.class);
+        assertThat(plan.estimatedClearance()).isEqualTo(Duration.ofMinutes(5));
+        assertThat(plan.reason()).isEqualTo("Mempool congestion expected to clear");
+    }
+
+    @Test
+    void shouldCreateWaitPlan_whenEstimatedClearanceIsNull() {
+        // when
+        var plan = RecoveryPlan.Wait.builder()
+                .reason("Unknown clearance time")
+                .build();
+
+        // then
+        assertThat(plan.estimatedClearance()).isNull();
+        assertThat(plan.reason()).isEqualTo("Unknown clearance time");
+    }
+
+    @Test
+    void shouldPatternMatchAllVariants() {
+        // given
+        var fee = FeeEstimate.builder()
+                .estimatedCost(new BigDecimal("0.005"))
+                .denomination("ETH")
+                .urgency(FeeUrgency.FAST)
+                .build();
+
+        RecoveryPlan speedUp = RecoveryPlan.SpeedUp.builder()
+                .originalTxHash("0x1")
+                .newFee(fee)
+                .build();
+        RecoveryPlan cancel = RecoveryPlan.Cancel.builder()
+                .originalTxHash("0x2")
+                .build();
+        RecoveryPlan resubmit = RecoveryPlan.Resubmit.builder()
+                .originalTxHash("0x3")
+                .build();
+        RecoveryPlan wait = RecoveryPlan.Wait.builder()
+                .reason("congestion")
+                .build();
+
+        // when / then — exhaustive switch
+        assertThat(describeAction(speedUp)).isEqualTo("speed-up");
+        assertThat(describeAction(cancel)).isEqualTo("cancel");
+        assertThat(describeAction(resubmit)).isEqualTo("resubmit");
+        assertThat(describeAction(wait)).isEqualTo("wait");
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenSpeedUpOriginalTxHashIsNull() {
+        // given
+        var fee = FeeEstimate.builder()
+                .estimatedCost(new BigDecimal("0.005"))
+                .denomination("ETH")
+                .urgency(FeeUrgency.FAST)
+                .build();
+
+        // when / then
+        assertThatThrownBy(() -> RecoveryPlan.SpeedUp.builder()
+                .originalTxHash(null)
+                .newFee(fee)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenSpeedUpNewFeeIsNull() {
+        // when / then
+        assertThatThrownBy(() -> RecoveryPlan.SpeedUp.builder()
+                .originalTxHash("0xabc")
+                .newFee(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenCancelOriginalTxHashIsNull() {
+        // when / then
+        assertThatThrownBy(() -> RecoveryPlan.Cancel.builder()
+                .originalTxHash(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenResubmitOriginalTxHashIsNull() {
+        // when / then
+        assertThatThrownBy(() -> RecoveryPlan.Resubmit.builder()
+                .originalTxHash(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenWaitReasonIsNull() {
+        // when / then
+        assertThatThrownBy(() -> RecoveryPlan.Wait.builder()
+                .reason(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private String describeAction(RecoveryPlan plan) {
+        return switch (plan) {
+            case RecoveryPlan.SpeedUp _ -> "speed-up";
+            case RecoveryPlan.Cancel _ -> "cancel";
+            case RecoveryPlan.Resubmit _ -> "resubmit";
+            case RecoveryPlan.Wait _ -> "wait";
+        };
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/SubmissionResourceTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/SubmissionResourceTest.java
@@ -1,0 +1,199 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.Test;
+
+class SubmissionResourceTest {
+
+    @Test
+    void shouldCreateEvmSubmissionResource() {
+        // when
+        var resource = EvmSubmissionResource.builder()
+                .chain("ethereum")
+                .fromAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18")
+                .nonce(42)
+                .tier(AddressTier.HOT)
+                .build();
+
+        // then
+        assertThat(resource).isInstanceOf(SubmissionResource.class);
+        assertThat(resource.chain()).isEqualTo("ethereum");
+        assertThat(resource.fromAddress()).isEqualTo("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18");
+        assertThat(resource.nonce()).isEqualTo(42);
+        assertThat(resource.tier()).isEqualTo(AddressTier.HOT);
+    }
+
+    @Test
+    void shouldCreateSolanaSubmissionResource() {
+        // when
+        var resource = SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress("5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d")
+                .nonceAccountAddress("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM")
+                .nonceValue("abc123nonce")
+                .build();
+
+        // then
+        assertThat(resource).isInstanceOf(SubmissionResource.class);
+        assertThat(resource.chain()).isEqualTo("solana");
+        assertThat(resource.fromAddress()).isEqualTo("5eykt4UsFv8P8NJdTREpY1vzqKqZKvdpKuc147dw2N9d");
+        assertThat(resource.nonceAccountAddress()).isEqualTo("9WzDXwBbmkg8ZTbNMqUxvQRAyrZzDsGYdLVL9zYtAWWM");
+        assertThat(resource.nonceValue()).isEqualTo("abc123nonce");
+    }
+
+    @Test
+    void shouldAccessChainViaSubmissionResourceInterface() {
+        // given
+        SubmissionResource evmResource = EvmSubmissionResource.builder()
+                .chain("base")
+                .fromAddress("0xabc")
+                .nonce(1)
+                .tier(AddressTier.PRIORITY)
+                .build();
+        SubmissionResource solanaResource = SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress("SolAddr123")
+                .nonceAccountAddress("NonceAcct456")
+                .nonceValue("nonce789")
+                .build();
+
+        // when / then
+        assertThat(evmResource.chain()).isEqualTo("base");
+        assertThat(solanaResource.chain()).isEqualTo("solana");
+    }
+
+    @Test
+    void shouldAccessFromAddressViaSubmissionResourceInterface() {
+        // given
+        SubmissionResource evmResource = EvmSubmissionResource.builder()
+                .chain("polygon")
+                .fromAddress("0xEvmAddr")
+                .nonce(5)
+                .tier(AddressTier.COLD)
+                .build();
+        SubmissionResource solanaResource = SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress("SolAddr")
+                .nonceAccountAddress("NonceAcct")
+                .nonceValue("nonce")
+                .build();
+
+        // when / then
+        assertThat(evmResource.fromAddress()).isEqualTo("0xEvmAddr");
+        assertThat(solanaResource.fromAddress()).isEqualTo("SolAddr");
+    }
+
+    @Test
+    void shouldPatternMatchSubmissionResourceVariants() {
+        // given
+        SubmissionResource evmResource = EvmSubmissionResource.builder()
+                .chain("ethereum")
+                .fromAddress("0x123")
+                .nonce(10)
+                .tier(AddressTier.HOT)
+                .build();
+        SubmissionResource solanaResource = SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress("Sol123")
+                .nonceAccountAddress("Nonce456")
+                .nonceValue("val789")
+                .build();
+
+        // when / then — exhaustive switch
+        assertThat(describeResource(evmResource)).isEqualTo("evm");
+        assertThat(describeResource(solanaResource)).isEqualTo("solana");
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenEvmChainIsNull() {
+        // when / then
+        assertThatThrownBy(() -> EvmSubmissionResource.builder()
+                .chain(null)
+                .fromAddress("0x123")
+                .nonce(1)
+                .tier(AddressTier.HOT)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenEvmFromAddressIsNull() {
+        // when / then
+        assertThatThrownBy(() -> EvmSubmissionResource.builder()
+                .chain("ethereum")
+                .fromAddress(null)
+                .nonce(1)
+                .tier(AddressTier.HOT)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenEvmTierIsNull() {
+        // when / then
+        assertThatThrownBy(() -> EvmSubmissionResource.builder()
+                .chain("ethereum")
+                .fromAddress("0x123")
+                .nonce(1)
+                .tier(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenSolanaChainIsNull() {
+        // when / then
+        assertThatThrownBy(() -> SolanaSubmissionResource.builder()
+                .chain(null)
+                .fromAddress("Sol123")
+                .nonceAccountAddress("Nonce456")
+                .nonceValue("val789")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenSolanaFromAddressIsNull() {
+        // when / then
+        assertThatThrownBy(() -> SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress(null)
+                .nonceAccountAddress("Nonce456")
+                .nonceValue("val789")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenSolanaNonceAccountAddressIsNull() {
+        // when / then
+        assertThatThrownBy(() -> SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress("Sol123")
+                .nonceAccountAddress(null)
+                .nonceValue("val789")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenSolanaNonceValueIsNull() {
+        // when / then
+        assertThatThrownBy(() -> SolanaSubmissionResource.builder()
+                .chain("solana")
+                .fromAddress("Sol123")
+                .nonceAccountAddress("Nonce456")
+                .nonceValue(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    private String describeResource(SubmissionResource resource) {
+        return switch (resource) {
+            case EvmSubmissionResource _ -> "evm";
+            case SolanaSubmissionResource _ -> "solana";
+        };
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/TransactionIntentTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/domain/model/TransactionIntentTest.java
@@ -1,0 +1,136 @@
+package com.stablebridge.txrecovery.domain.model;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.time.Instant;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+class TransactionIntentTest {
+
+    @Test
+    void shouldCreateTransactionIntent() {
+        // given
+        var now = Instant.now();
+
+        // when
+        var intent = TransactionIntent.builder()
+                .intentId("intent-001")
+                .chain("ethereum")
+                .toAddress("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18")
+                .amount(new BigDecimal("100.50"))
+                .token("USDC")
+                .tokenDecimals(6)
+                .rawAmount(BigInteger.valueOf(100500000L))
+                .tokenContractAddress("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48")
+                .strategy(SubmissionStrategy.SEQUENTIAL)
+                .metadata(Map.of("orderId", "ORD-123"))
+                .batchId("batch-001")
+                .createdAt(now)
+                .build();
+
+        // then
+        assertThat(intent.intentId()).isEqualTo("intent-001");
+        assertThat(intent.chain()).isEqualTo("ethereum");
+        assertThat(intent.toAddress()).isEqualTo("0x742d35Cc6634C0532925a3b844Bc9e7595f2bD18");
+        assertThat(intent.amount()).isEqualByComparingTo(new BigDecimal("100.50"));
+        assertThat(intent.token()).isEqualTo("USDC");
+        assertThat(intent.tokenDecimals()).isEqualTo(6);
+        assertThat(intent.rawAmount()).isEqualTo(BigInteger.valueOf(100500000L));
+        assertThat(intent.tokenContractAddress()).isEqualTo("0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48");
+        assertThat(intent.strategy()).isEqualTo(SubmissionStrategy.SEQUENTIAL);
+        assertThat(intent.metadata()).containsEntry("orderId", "ORD-123");
+        assertThat(intent.batchId()).isEqualTo("batch-001");
+        assertThat(intent.createdAt()).isEqualTo(now);
+    }
+
+    @Test
+    void shouldCreateTransactionIntent_whenOptionalFieldsAreNull() {
+        // when
+        var intent = TransactionIntent.builder()
+                .intentId("intent-002")
+                .chain("base")
+                .toAddress("0xabc")
+                .amount(new BigDecimal("50"))
+                .token("ETH")
+                .build();
+
+        // then
+        assertThat(intent.intentId()).isEqualTo("intent-002");
+        assertThat(intent.rawAmount()).isNull();
+        assertThat(intent.tokenContractAddress()).isNull();
+        assertThat(intent.strategy()).isNull();
+        assertThat(intent.metadata()).isNull();
+        assertThat(intent.batchId()).isNull();
+        assertThat(intent.createdAt()).isNull();
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenIntentIdIsNull() {
+        // when / then
+        assertThatThrownBy(() -> TransactionIntent.builder()
+                .intentId(null)
+                .chain("ethereum")
+                .toAddress("0xabc")
+                .amount(new BigDecimal("10"))
+                .token("USDC")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenChainIsNull() {
+        // when / then
+        assertThatThrownBy(() -> TransactionIntent.builder()
+                .intentId("intent-001")
+                .chain(null)
+                .toAddress("0xabc")
+                .amount(new BigDecimal("10"))
+                .token("USDC")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenToAddressIsNull() {
+        // when / then
+        assertThatThrownBy(() -> TransactionIntent.builder()
+                .intentId("intent-001")
+                .chain("ethereum")
+                .toAddress(null)
+                .amount(new BigDecimal("10"))
+                .token("USDC")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenAmountIsNull() {
+        // when / then
+        assertThatThrownBy(() -> TransactionIntent.builder()
+                .intentId("intent-001")
+                .chain("ethereum")
+                .toAddress("0xabc")
+                .amount(null)
+                .token("USDC")
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+
+    @Test
+    void shouldThrowNullPointerException_whenTokenIsNull() {
+        // when / then
+        assertThatThrownBy(() -> TransactionIntent.builder()
+                .intentId("intent-001")
+                .chain("ethereum")
+                .toAddress("0xabc")
+                .amount(new BigDecimal("10"))
+                .token(null)
+                .build())
+                .isInstanceOf(NullPointerException.class);
+    }
+}


### PR DESCRIPTION
## STR Issue
Closes #2

## Changes
- 26 domain model records in `com.stablebridge.txrecovery.domain.model`:
  - Core aggregates: `TransactionIntent`, `SubmittedTransaction`, `RecoveryAttempt`
  - Sealed types: `RecoveryPlan` (SpeedUp/Cancel/Resubmit/Wait), `SubmissionResource` (Evm/Solana)
  - Business logic: `GasBudgetPolicy.calculateBudget()` with floor/ceiling clamping
  - Value objects: `EscalationTier`, `EscalationPolicy`, `FeeEstimate`, `PooledAddress`, `NonceAllocation`, `SolanaNonceAccount`
  - Transaction lifecycle: `UnsignedTransaction`, `SignedTransaction`, `BroadcastResult`, `ConfirmationStatus`
  - Recovery: `StuckAssessment`, `RecoveryResult`, `HumanApproval`, `CancelRequest`
  - Query/projection: `TransactionResult`, `TransactionSnapshot`, `TransactionProjection`, `TransactionFilters`
- 38 unit tests across 4 test classes (GasBudgetPolicy, RecoveryPlan, SubmissionResource, TransactionIntent)
- All records framework-free — only Lombok `@Builder`, compact constructors with `Objects.requireNonNull()`

## Dependencies
- Based on `feature/STR-3-domain-enums` (PR #52) — enums must merge first

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added (38 tests)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied
- [x] All records in `domain/model/` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)