### PR TITLE
STR-5: enforce hexagonal architecture rules via ArchUnit

### DIFF
--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/ArchitectureTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/ArchitectureTest.java
@@ -1,0 +1,61 @@
+package com.stablebridge.txrecovery;
+
+import static com.tngtech.archunit.base.DescribedPredicate.not;
+import static com.tngtech.archunit.core.domain.JavaClass.Predicates.resideInAnyPackage;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+@AnalyzeClasses(packages = "com.stablebridge.txrecovery")
+class ArchitectureTest {
+
+    @ArchTest
+    static final ArchRule domainMustNotDependOnInfrastructure = noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..infrastructure..")
+            .allowEmptyShould(true);
+
+    @ArchTest
+    static final ArchRule domainMustNotDependOnApplication = noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..application..")
+            .allowEmptyShould(true);
+
+    @ArchTest
+    static final ArchRule domainMustNotImportSpring = noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat(
+                    resideInAnyPackage("org.springframework..")
+                            .and(not(resideInAnyPackage(
+                                    "org.springframework.stereotype..",
+                                    "org.springframework.transaction.annotation.."))))
+            .allowEmptyShould(true);
+
+    @ArchTest
+    static final ArchRule domainMustNotImportJakartaPersistence = noClasses()
+            .that()
+            .resideInAPackage("..domain..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("jakarta.persistence..")
+            .allowEmptyShould(true);
+
+    @ArchTest
+    static final ArchRule infrastructureMustNotDependOnControllers = noClasses()
+            .that()
+            .resideInAPackage("..infrastructure..")
+            .should()
+            .dependOnClassesThat()
+            .resideInAPackage("..application.controller..")
+            .allowEmptyShould(true);
+}


### PR DESCRIPTION
## STR Issue
Closes #5

## Changes
- Add ArchitectureTest with 5 hexagonal architecture rules enforced via ArchUnit
- Rule 1: Domain must not depend on infrastructure
- Rule 2: Domain must not depend on application
- Rule 3: Domain must not import Spring (except `@Service` and `@Transactional`)
- Rule 4: Domain must not import `jakarta.persistence`
- Rule 5: Infrastructure must not depend on controllers
- All rules use `allowEmptyShould(true)` to handle packages with no classes yet

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added architecture validation tests to enforce code structure integrity and maintain consistent dependency boundaries across the codebase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->