### PR TITLE
STR-11: add Solana JSON-RPC client with resilience

### DIFF
--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/JsonRpcRequest.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/JsonRpcRequest.java
@@ -1,0 +1,10 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+import java.util.List;
+
+record JsonRpcRequest(String jsonrpc, long id, String method, List<Object> params) {
+
+    JsonRpcRequest(long id, String method, List<Object> params) {
+        this("2.0", id, method, params);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/JsonRpcResponse.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/JsonRpcResponse.java
@@ -1,0 +1,6 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+record JsonRpcResponse<T>(String jsonrpc, long id, T result, JsonRpcError error) {
+
+    record JsonRpcError(int code, String message, Object data) {}
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaAccountInfo.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaAccountInfo.java
@@ -1,0 +1,8 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+import java.util.List;
+
+record SolanaAccountInfo(SolanaAccountValue value) {
+
+    record SolanaAccountValue(List<String> data, String owner, long lamports, boolean executable) {}
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaBlockhash.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaBlockhash.java
@@ -1,0 +1,6 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+record SolanaBlockhash(SolanaBlockhashValue value) {
+
+    record SolanaBlockhashValue(String blockhash, long lastValidBlockHeight) {}
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaBlockhashValidity.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaBlockhashValidity.java
@@ -1,0 +1,3 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+record SolanaBlockhashValidity(boolean value) {}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaCommitment.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaCommitment.java
@@ -1,0 +1,11 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+public enum SolanaCommitment {
+    PROCESSED,
+    CONFIRMED,
+    FINALIZED;
+
+    String value() {
+        return name().toLowerCase();
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaPrioritizationFee.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaPrioritizationFee.java
@@ -1,0 +1,3 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+record SolanaPrioritizationFee(long slot, long prioritizationFee) {}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaRpcClient.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaRpcClient.java
@@ -1,0 +1,165 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import lombok.extern.slf4j.Slf4j;
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+@Slf4j
+public class SolanaRpcClient {
+
+    private static final String CONTENT_TYPE = "application/json";
+
+    private final HttpClient httpClient;
+    private final ObjectMapper objectMapper;
+    private final List<URI> rpcEndpoints;
+    private final CircuitBreaker circuitBreaker;
+    private final RateLimiter rateLimiter;
+    private final AtomicLong requestIdCounter;
+
+    public SolanaRpcClient(
+            HttpClient httpClient,
+            ObjectMapper objectMapper,
+            List<URI> rpcEndpoints,
+            CircuitBreaker circuitBreaker,
+            RateLimiter rateLimiter) {
+        this.httpClient = httpClient;
+        this.objectMapper = objectMapper;
+        this.rpcEndpoints = List.copyOf(rpcEndpoints);
+        this.circuitBreaker = circuitBreaker;
+        this.rateLimiter = rateLimiter;
+        this.requestIdCounter = new AtomicLong(1);
+    }
+
+    public String sendTransaction(byte[] signedTransaction) {
+        var encoded = Base64.getEncoder().encodeToString(signedTransaction);
+        var config = Map.of("encoding", "base64", "skipPreflight", false);
+        var params = List.<Object>of(encoded, config);
+        var request = new JsonRpcRequest(nextId(), "sendTransaction", params);
+        return execute(request, new TypeReference<JsonRpcResponse<String>>() {});
+    }
+
+    public List<SolanaSignatureStatus> getSignatureStatuses(List<String> signatures) {
+        var config = Map.of("searchTransactionHistory", true);
+        var params = List.<Object>of(signatures, config);
+        var request = new JsonRpcRequest(nextId(), "getSignatureStatuses", params);
+        var response = execute(
+                request,
+                new TypeReference<JsonRpcResponse<SolanaSignatureStatusResult>>() {});
+        return response.value();
+    }
+
+    public List<SolanaPrioritizationFee> getRecentPrioritizationFees(List<String> accountKeys) {
+        var params = accountKeys.isEmpty() ? List.<Object>of() : List.<Object>of(accountKeys);
+        var request = new JsonRpcRequest(nextId(), "getRecentPrioritizationFees", params);
+        return execute(request, new TypeReference<JsonRpcResponse<List<SolanaPrioritizationFee>>>() {});
+    }
+
+    public String getNonce(String nonceAccountAddress, SolanaCommitment commitment) {
+        var config = Map.of("encoding", "base64", "commitment", commitment.value());
+        var params = List.<Object>of(nonceAccountAddress, config);
+        var request = new JsonRpcRequest(nextId(), "getAccountInfo", params);
+        var accountInfo =
+                execute(request, new TypeReference<JsonRpcResponse<SolanaAccountInfo>>() {});
+        if (accountInfo == null || accountInfo.value() == null) {
+            throw new SolanaRpcException(-1, "Nonce account not found: " + nonceAccountAddress);
+        }
+        return accountInfo.value().data().getFirst();
+    }
+
+    public boolean isBlockhashValid(String blockhash, SolanaCommitment commitment) {
+        var config = Map.of("commitment", commitment.value());
+        var params = List.<Object>of(blockhash, config);
+        var request = new JsonRpcRequest(nextId(), "isBlockhashValid", params);
+        var validity =
+                execute(request, new TypeReference<JsonRpcResponse<SolanaBlockhashValidity>>() {});
+        return validity.value();
+    }
+
+    public SolanaBlockhash getLatestBlockhash(SolanaCommitment commitment) {
+        var config = Map.of("commitment", commitment.value());
+        var params = List.<Object>of(config);
+        var request = new JsonRpcRequest(nextId(), "getLatestBlockhash", params);
+        return execute(request, new TypeReference<JsonRpcResponse<SolanaBlockhash>>() {});
+    }
+
+    public SolanaAccountInfo getAccountInfo(String address, SolanaCommitment commitment) {
+        var config = Map.of("encoding", "base64", "commitment", commitment.value());
+        var params = List.<Object>of(address, config);
+        var request = new JsonRpcRequest(nextId(), "getAccountInfo", params);
+        return execute(request, new TypeReference<JsonRpcResponse<SolanaAccountInfo>>() {});
+    }
+
+    private <T> T execute(JsonRpcRequest rpcRequest, TypeReference<JsonRpcResponse<T>> responseType) {
+        return CircuitBreaker.decorateSupplier(
+                        circuitBreaker,
+                        RateLimiter.decorateSupplier(
+                                rateLimiter, () -> executeWithFallback(rpcRequest, responseType)))
+                .get();
+    }
+
+    private <T> T executeWithFallback(
+            JsonRpcRequest rpcRequest, TypeReference<JsonRpcResponse<T>> responseType) {
+        RuntimeException lastException = null;
+        for (var endpoint : rpcEndpoints) {
+            try {
+                return executeRequest(endpoint, rpcRequest, responseType);
+            } catch (RuntimeException e) {
+                log.warn("RPC call to {} failed, trying next endpoint", endpoint, e);
+                lastException = e;
+            }
+        }
+        throw lastException;
+    }
+
+    private <T> T executeRequest(
+            URI endpoint,
+            JsonRpcRequest rpcRequest,
+            TypeReference<JsonRpcResponse<T>> responseType) {
+        try {
+            var body = objectMapper.writeValueAsString(rpcRequest);
+            var httpRequest = HttpRequest.newBuilder()
+                    .uri(endpoint)
+                    .header("Content-Type", CONTENT_TYPE)
+                    .POST(HttpRequest.BodyPublishers.ofString(body))
+                    .build();
+
+            var httpResponse = httpClient.send(httpRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (httpResponse.statusCode() != 200) {
+                throw new SolanaRpcException(
+                        -1,
+                        "HTTP " + httpResponse.statusCode() + " from " + endpoint);
+            }
+
+            var rpcResponse = objectMapper.readValue(httpResponse.body(), responseType);
+
+            if (rpcResponse.error() != null) {
+                throw new SolanaRpcException(
+                        rpcResponse.error().code(), rpcResponse.error().message());
+            }
+
+            return rpcResponse.result();
+        } catch (SolanaRpcException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new SolanaRpcException("RPC call failed: " + rpcRequest.method(), e);
+        }
+    }
+
+    private long nextId() {
+        return requestIdCounter.getAndIncrement();
+    }
+
+    record SolanaSignatureStatusResult(List<SolanaSignatureStatus> value) {}
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaRpcException.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaRpcException.java
@@ -1,0 +1,20 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+public class SolanaRpcException extends RuntimeException {
+
+    private final int rpcErrorCode;
+
+    SolanaRpcException(int rpcErrorCode, String message) {
+        super(message);
+        this.rpcErrorCode = rpcErrorCode;
+    }
+
+    SolanaRpcException(String message, Throwable cause) {
+        super(message, cause);
+        this.rpcErrorCode = -1;
+    }
+
+    public int rpcErrorCode() {
+        return rpcErrorCode;
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaSignatureStatus.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaSignatureStatus.java
@@ -1,0 +1,20 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+record SolanaSignatureStatus(
+        Long slot,
+        Long confirmations,
+        String confirmationStatus,
+        Object err) {
+
+    boolean isConfirmedOrFinalized() {
+        return "confirmed".equals(confirmationStatus) || "finalized".equals(confirmationStatus);
+    }
+
+    boolean isFinalized() {
+        return "finalized".equals(confirmationStatus);
+    }
+
+    boolean hasError() {
+        return err != null;
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaRpcClientTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/infrastructure/client/solana/SolanaRpcClientTest.java
@@ -1,0 +1,665 @@
+package com.stablebridge.txrecovery.infrastructure.client.solana;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalToJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.util.Base64;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.RateLimiter;
+import tools.jackson.databind.ObjectMapper;
+
+@WireMockTest
+class SolanaRpcClientTest {
+
+    private static final byte[] SOME_SIGNED_TX = new byte[] {1, 2, 3, 4, 5};
+    private static final String SOME_TX_SIGNATURE =
+            "5VERv8NMvzbJMEkV8xnrLkEaWRtSz9CosKDYjCJjBRnbJLgp8uirBgmQpjKhoR4tjF3ZpRzrFmBV6UjKdiSZkQU";
+    private static final String SOME_NONCE_ACCOUNT = "NonceAcct111111111111111111111111111111";
+    private static final String SOME_BLOCKHASH = "EETubP5AKHgjPAhzPkA6E6Q25cUFzPSQ4Sfp1kH3Lz9N";
+    private static final String SOME_ADDRESS = "Vote111111111111111111111111111111111111111";
+
+    private SolanaRpcClient client;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo wmInfo) {
+        var objectMapper = new ObjectMapper();
+        var httpClient = HttpClient.newBuilder()
+                .version(HttpClient.Version.HTTP_1_1)
+                .build();
+        var endpoint = URI.create(wmInfo.getHttpBaseUrl());
+        var circuitBreaker = CircuitBreaker.ofDefaults("solana-test");
+        var rateLimiter = RateLimiter.ofDefaults("solana-test");
+
+        client = new SolanaRpcClient(
+                httpClient, objectMapper, List.of(endpoint), circuitBreaker, rateLimiter);
+    }
+
+    @Nested
+    class SendTransaction {
+
+        @Test
+        void shouldSendBase64EncodedTransactionAndReturnSignature(WireMockRuntimeInfo wmInfo) {
+            // given
+            var encoded = Base64.getEncoder().encodeToString(SOME_SIGNED_TX);
+            var expectedRequest = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "method": "sendTransaction",
+                      "params": ["%s", {"encoding": "base64", "skipPreflight": false}]
+                    }"""
+                    .formatted(encoded);
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "result": "%s"
+                    }"""
+                    .formatted(SOME_TX_SIGNATURE);
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .withRequestBody(equalToJson(expectedRequest, true, false))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.sendTransaction(SOME_SIGNED_TX);
+
+            // then
+            assertThat(result).isEqualTo(SOME_TX_SIGNATURE);
+        }
+
+        @Test
+        void shouldThrowOnRpcError(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "error": {
+                        "code": -32002,
+                        "message": "Transaction simulation failed"
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when/then
+            assertThatThrownBy(() -> client.sendTransaction(SOME_SIGNED_TX))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("Transaction simulation failed");
+        }
+    }
+
+    @Nested
+    class GetSignatureStatuses {
+
+        @Test
+        void shouldReturnSignatureStatuses(WireMockRuntimeInfo wmInfo) {
+            // given
+            var signatures = List.of(SOME_TX_SIGNATURE);
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "result": {
+                        "value": [
+                          {
+                            "slot": 123456,
+                            "confirmations": 10,
+                            "confirmationStatus": "confirmed",
+                            "err": null
+                          }
+                        ]
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getSignatureStatuses(signatures);
+
+            // then
+            assertThat(result).hasSize(1);
+            var expected = new SolanaSignatureStatus(123456L, 10L, "confirmed", null);
+            assertThat(result.getFirst())
+                    .usingRecursiveComparison()
+                    .isEqualTo(expected);
+        }
+
+        @Test
+        void shouldReturnNullEntryForUnknownSignature(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "result": {
+                        "value": [null]
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getSignatureStatuses(List.of("unknownSig"));
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst()).isNull();
+        }
+
+        @Test
+        void shouldReturnStatusWithError(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 2,
+                      "result": {
+                        "value": [
+                          {
+                            "slot": 789,
+                            "confirmations": null,
+                            "confirmationStatus": "finalized",
+                            "err": {"InstructionError": [0, "Custom"]}
+                          }
+                        ]
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getSignatureStatuses(List.of(SOME_TX_SIGNATURE));
+
+            // then
+            assertThat(result).hasSize(1);
+            assertThat(result.getFirst().hasError()).isTrue();
+            assertThat(result.getFirst().isFinalized()).isTrue();
+        }
+    }
+
+    @Nested
+    class GetRecentPrioritizationFees {
+
+        @Test
+        void shouldReturnPrioritizationFees(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 3,
+                      "result": [
+                        {"slot": 100, "prioritizationFee": 5000},
+                        {"slot": 101, "prioritizationFee": 6000}
+                      ]
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getRecentPrioritizationFees(List.of(SOME_ADDRESS));
+
+            // then
+            assertThat(result).hasSize(2);
+            assertThat(result.getFirst())
+                    .usingRecursiveComparison()
+                    .isEqualTo(new SolanaPrioritizationFee(100L, 5000L));
+            assertThat(result.getLast())
+                    .usingRecursiveComparison()
+                    .isEqualTo(new SolanaPrioritizationFee(101L, 6000L));
+        }
+
+        @Test
+        void shouldReturnEmptyListWhenNoFees(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 3,
+                      "result": []
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getRecentPrioritizationFees(List.of());
+
+            // then
+            assertThat(result).isEmpty();
+        }
+    }
+
+    @Nested
+    class GetNonce {
+
+        @Test
+        void shouldReturnNonceDataFromAccountInfo(WireMockRuntimeInfo wmInfo) {
+            // given
+            var nonceData = "SGVsbG8gV29ybGQ=";
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 4,
+                      "result": {
+                        "value": {
+                          "data": ["%s", "base64"],
+                          "owner": "11111111111111111111111111111111",
+                          "lamports": 1447680,
+                          "executable": false
+                        }
+                      }
+                    }"""
+                    .formatted(nonceData);
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getNonce(SOME_NONCE_ACCOUNT, SolanaCommitment.CONFIRMED);
+
+            // then
+            assertThat(result).isEqualTo(nonceData);
+        }
+
+        @Test
+        void shouldThrowWhenNonceAccountNotFound(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 4,
+                      "result": {
+                        "value": null
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when/then
+            assertThatThrownBy(
+                            () -> client.getNonce(SOME_NONCE_ACCOUNT, SolanaCommitment.CONFIRMED))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("Nonce account not found");
+        }
+    }
+
+    @Nested
+    class IsBlockhashValid {
+
+        @Test
+        void shouldReturnTrueForValidBlockhash(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 5,
+                      "result": {
+                        "value": true
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.isBlockhashValid(SOME_BLOCKHASH, SolanaCommitment.FINALIZED);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseForExpiredBlockhash(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 5,
+                      "result": {
+                        "value": false
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.isBlockhashValid(SOME_BLOCKHASH, SolanaCommitment.FINALIZED);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class GetLatestBlockhash {
+
+        @Test
+        void shouldReturnLatestBlockhash(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 6,
+                      "result": {
+                        "value": {
+                          "blockhash": "%s",
+                          "lastValidBlockHeight": 200000
+                        }
+                      }
+                    }"""
+                    .formatted(SOME_BLOCKHASH);
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getLatestBlockhash(SolanaCommitment.FINALIZED);
+
+            // then
+            var expected = new SolanaBlockhash(
+                    new SolanaBlockhash.SolanaBlockhashValue(SOME_BLOCKHASH, 200000L));
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+    }
+
+    @Nested
+    class GetAccountInfo {
+
+        @Test
+        void shouldReturnAccountInfo(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 7,
+                      "result": {
+                        "value": {
+                          "data": ["AQAAAA==", "base64"],
+                          "owner": "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                          "lamports": 2039280,
+                          "executable": false
+                        }
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getAccountInfo(SOME_ADDRESS, SolanaCommitment.CONFIRMED);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.value()).isNotNull();
+            var expected = new SolanaAccountInfo(new SolanaAccountInfo.SolanaAccountValue(
+                    List.of("AQAAAA==", "base64"),
+                    "TokenkegQfeZyiNwAJbNbGKPFXCWuBvf9Ss623VQ5DA",
+                    2039280L,
+                    false));
+            assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+        }
+
+        @Test
+        void shouldReturnNullValueForNonExistentAccount(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 7,
+                      "result": {
+                        "value": null
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = client.getAccountInfo(SOME_ADDRESS, SolanaCommitment.CONFIRMED);
+
+            // then
+            assertThat(result).isNotNull();
+            assertThat(result.value()).isNull();
+        }
+    }
+
+    @Nested
+    class ErrorHandling {
+
+        @Test
+        void shouldThrowOnHttpError(WireMockRuntimeInfo wmInfo) {
+            // given
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse().withStatus(503)));
+
+            // when/then
+            assertThatThrownBy(() -> client.sendTransaction(SOME_SIGNED_TX))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("HTTP 503");
+        }
+
+        @Test
+        void shouldThrowOnJsonRpcError(WireMockRuntimeInfo wmInfo) {
+            // given
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "error": {
+                        "code": -32600,
+                        "message": "Invalid request"
+                      }
+                    }""";
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when/then
+            assertThatThrownBy(() -> client.sendTransaction(SOME_SIGNED_TX))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("Invalid request");
+        }
+
+        @Test
+        void shouldThrowOnConnectionError() {
+            // given
+            var badEndpoint = URI.create("http://localhost:1");
+            var httpClient = HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .build();
+            var objectMapper = new ObjectMapper();
+            var brokenClient = new SolanaRpcClient(
+                    httpClient,
+                    objectMapper,
+                    List.of(badEndpoint),
+                    CircuitBreaker.ofDefaults("broken-test"),
+                    RateLimiter.ofDefaults("broken-test"));
+
+            // when/then
+            assertThatThrownBy(() -> brokenClient.sendTransaction(SOME_SIGNED_TX))
+                    .isInstanceOf(SolanaRpcException.class)
+                    .hasMessageContaining("RPC call failed");
+        }
+    }
+
+    @Nested
+    class UrlFallback {
+
+        @Test
+        void shouldFallbackToSecondEndpoint(WireMockRuntimeInfo wmInfo) {
+            // given
+            var badEndpoint = URI.create("http://localhost:1");
+            var goodEndpoint = URI.create(wmInfo.getHttpBaseUrl());
+            var httpClient = HttpClient.newBuilder()
+                    .version(HttpClient.Version.HTTP_1_1)
+                    .build();
+            var objectMapper = new ObjectMapper();
+            var fallbackClient = new SolanaRpcClient(
+                    httpClient,
+                    objectMapper,
+                    List.of(badEndpoint, goodEndpoint),
+                    CircuitBreaker.ofDefaults("fallback-test"),
+                    RateLimiter.ofDefaults("fallback-test"));
+
+            var responseBody = """
+                    {
+                      "jsonrpc": "2.0",
+                      "id": 1,
+                      "result": "%s"
+                    }"""
+                    .formatted(SOME_TX_SIGNATURE);
+
+            wmInfo.getWireMock()
+                    .register(post(urlEqualTo("/"))
+                            .willReturn(aResponse()
+                                    .withStatus(200)
+                                    .withHeader("Content-Type", "application/json")
+                                    .withBody(responseBody)));
+
+            // when
+            var result = fallbackClient.sendTransaction(SOME_SIGNED_TX);
+
+            // then
+            assertThat(result).isEqualTo(SOME_TX_SIGNATURE);
+        }
+    }
+
+    @Nested
+    class SolanaCommitmentValues {
+
+        @Test
+        void shouldReturnLowercaseValues() {
+            assertThat(SolanaCommitment.PROCESSED.value()).isEqualTo("processed");
+            assertThat(SolanaCommitment.CONFIRMED.value()).isEqualTo("confirmed");
+            assertThat(SolanaCommitment.FINALIZED.value()).isEqualTo("finalized");
+        }
+    }
+
+    @Nested
+    class SolanaSignatureStatusBehavior {
+
+        @Test
+        void shouldIdentifyConfirmedStatus() {
+            // given
+            var status = new SolanaSignatureStatus(100L, 5L, "confirmed", null);
+
+            // when/then
+            assertThat(status.isConfirmedOrFinalized()).isTrue();
+            assertThat(status.isFinalized()).isFalse();
+            assertThat(status.hasError()).isFalse();
+        }
+
+        @Test
+        void shouldIdentifyFinalizedStatus() {
+            // given
+            var status = new SolanaSignatureStatus(100L, null, "finalized", null);
+
+            // when/then
+            assertThat(status.isConfirmedOrFinalized()).isTrue();
+            assertThat(status.isFinalized()).isTrue();
+        }
+
+        @Test
+        void shouldIdentifyProcessedAsNotConfirmed() {
+            // given
+            var status = new SolanaSignatureStatus(100L, 0L, "processed", null);
+
+            // when/then
+            assertThat(status.isConfirmedOrFinalized()).isFalse();
+        }
+
+        @Test
+        void shouldDetectError() {
+            // given
+            var status = new SolanaSignatureStatus(100L, null, "finalized", "some error");
+
+            // when/then
+            assertThat(status.hasError()).isTrue();
+        }
+    }
+}


### PR DESCRIPTION
## STR Issue
Closes #11

## Changes
- Add `SolanaRpcClient` with all required RPC methods: sendTransaction, getSignatureStatuses, getRecentPrioritizationFees, getNonce, isBlockhashValid, getLatestBlockhash, getAccountInfo
- Implement JDK `HttpClient` with HTTP/1.1 and virtual thread executor (same pattern as EVM client)
- Add base64 transaction encoding and commitment level support (processed, confirmed, finalized)
- Add Resilience4j CircuitBreaker and RateLimiter integration per chain
- Add package-private DTOs for Solana-specific responses
- Add comprehensive WireMock tests for all RPC methods and error scenarios (665+ lines)

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied