### PR TITLE
STR-12: add API key security filter

### DIFF
--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilter.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilter.java
@@ -1,0 +1,55 @@
+package com.stablebridge.txrecovery.application.security;
+
+import java.io.IOException;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.springframework.http.MediaType;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+public class ApiKeyAuthFilter extends OncePerRequestFilter {
+
+    static final String API_KEY_HEADER = "X-API-Key";
+    static final String ERROR_CODE = "STR-4010";
+    static final String ERROR_MESSAGE = "Unauthorized";
+    static final String ERROR_RESPONSE_BODY =
+            "{\"error\": \"" + ERROR_CODE + "\", \"message\": \"" + ERROR_MESSAGE + "\"}";
+
+    private final String configuredApiKey;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        var providedKey = request.getHeader(API_KEY_HEADER);
+
+        if (configuredApiKey == null || configuredApiKey.isBlank()) {
+            log.warn("API key not configured — rejecting request to {}", request.getRequestURI());
+            sendUnauthorized(response);
+            return;
+        }
+
+        if (providedKey == null || !configuredApiKey.equals(providedKey)) {
+            log.warn("Invalid or missing API key for request to {}", request.getRequestURI());
+            sendUnauthorized(response);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void sendUnauthorized(HttpServletResponse response) throws IOException {
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.getWriter().write(ERROR_RESPONSE_BODY);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterConfig.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterConfig.java
@@ -1,0 +1,19 @@
+package com.stablebridge.txrecovery.application.security;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ApiKeyAuthFilterConfig {
+
+    @Bean
+    FilterRegistrationBean<ApiKeyAuthFilter> apiKeyAuthFilterRegistration(
+            @Value("${str.api.key:}") String apiKey) {
+        var registration = new FilterRegistrationBean<>(new ApiKeyAuthFilter(apiKey));
+        registration.addUrlPatterns("/api/v1/*");
+        registration.setOrder(1);
+        return registration;
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterTest.java
@@ -1,0 +1,116 @@
+package com.stablebridge.txrecovery.application.security;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+class ApiKeyAuthFilterTest {
+
+    static final String VALID_API_KEY = "test-secret-key-12345";
+    static final String API_ENDPOINT = "/api/v1/test";
+    static final String ACTUATOR_ENDPOINT = "/actuator/health";
+
+    @RestController
+    static class TestController {
+
+        @GetMapping("/api/v1/test")
+        ResponseEntity<String> apiEndpoint() {
+            return ResponseEntity.ok("{\"status\": \"ok\"}");
+        }
+
+        @GetMapping("/actuator/health")
+        ResponseEntity<String> actuatorEndpoint() {
+            return ResponseEntity.ok("{\"status\": \"UP\"}");
+        }
+    }
+
+    private MockMvc buildMockMvc(String apiKey) {
+        return MockMvcBuilders.standaloneSetup(new TestController())
+                .addFilter(new ApiKeyAuthFilter(apiKey), "/api/v1/*")
+                .build();
+    }
+
+    @Nested
+    class WhenApiKeyConfigured {
+
+        private final MockMvc mockMvc = buildMockMvc(VALID_API_KEY);
+
+        @Test
+        void shouldAllowRequestWithValidApiKey() throws Exception {
+            // when / then
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, VALID_API_KEY))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("{\"status\": \"ok\"}"));
+        }
+
+        @Test
+        void shouldRejectRequestWithInvalidApiKey() throws Exception {
+            // when / then
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "wrong-key"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andExpect(jsonPath("$.error").value(ApiKeyAuthFilter.ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(ApiKeyAuthFilter.ERROR_MESSAGE));
+        }
+
+        @Test
+        void shouldRejectRequestWithMissingApiKey() throws Exception {
+            // when / then
+            mockMvc.perform(get(API_ENDPOINT))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andExpect(jsonPath("$.error").value(ApiKeyAuthFilter.ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(ApiKeyAuthFilter.ERROR_MESSAGE));
+        }
+
+        @Test
+        void shouldAllowActuatorWithoutApiKey() throws Exception {
+            // when / then
+            mockMvc.perform(get(ACTUATOR_ENDPOINT))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("{\"status\": \"UP\"}"));
+        }
+    }
+
+    @Nested
+    class WhenApiKeyNotConfigured {
+
+        private final MockMvc mockMvc = buildMockMvc("");
+
+        @Test
+        void shouldRejectRequestWhenApiKeyNotConfigured() throws Exception {
+            // when / then
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "any-key"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andExpect(jsonPath("$.error").value(ApiKeyAuthFilter.ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(ApiKeyAuthFilter.ERROR_MESSAGE));
+        }
+    }
+
+    @Nested
+    class WhenApiKeyNull {
+
+        private final MockMvc mockMvc = buildMockMvc(null);
+
+        @Test
+        void shouldRejectRequestWhenApiKeyIsNull() throws Exception {
+            // when / then
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "any-key"))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
+                    .andExpect(jsonPath("$.error").value(ApiKeyAuthFilter.ERROR_CODE))
+                    .andExpect(jsonPath("$.message").value(ApiKeyAuthFilter.ERROR_MESSAGE));
+        }
+    }
+}


### PR DESCRIPTION
## STR Issue
Closes #12

## Changes
- Add `ApiKeyAuthFilter` extending `OncePerRequestFilter` validating `X-API-Key` header against `str.api.key` property
- Add `ApiKeyAuthFilterConfig` registering filter for `/api/v1/**` paths only
- Exclude `/actuator/**` paths from authentication
- Return 401 Unauthorized with JSON error body for missing/invalid keys
- Fail-secure: returns 401 if `str.api.key` is not configured
- Add unit tests with MockMvc verifying filter behavior (valid key, invalid key, missing key, actuator bypass)

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied