### PR TITLE
STR-18: add EVM recovery strategy with stuck assessment and RBF execution

### DIFF
--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/evm/EvmRecoveryStrategy.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/evm/EvmRecoveryStrategy.java
@@ -1,0 +1,309 @@
+package com.stablebridge.txrecovery.infrastructure.client.evm;
+
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.RoundingMode;
+import java.time.Duration;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Map;
+
+import com.stablebridge.txrecovery.domain.address.model.ChainFamily;
+import com.stablebridge.txrecovery.domain.recovery.model.FeeUrgency;
+import com.stablebridge.txrecovery.domain.recovery.model.RecoveryOutcome;
+import com.stablebridge.txrecovery.domain.recovery.model.RecoveryPlan;
+import com.stablebridge.txrecovery.domain.recovery.model.RecoveryResult;
+import com.stablebridge.txrecovery.domain.recovery.model.StuckAssessment;
+import com.stablebridge.txrecovery.domain.recovery.model.StuckReason;
+import com.stablebridge.txrecovery.domain.recovery.model.StuckSeverity;
+import com.stablebridge.txrecovery.domain.recovery.port.FeeOracle;
+import com.stablebridge.txrecovery.domain.recovery.port.RecoveryStrategy;
+import com.stablebridge.txrecovery.domain.transaction.model.SubmittedTransaction;
+import com.stablebridge.txrecovery.domain.transaction.model.UnsignedTransaction;
+import com.stablebridge.txrecovery.domain.transaction.port.TransactionSigner;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+class EvmRecoveryStrategy implements RecoveryStrategy {
+
+    private static final long CANCEL_GAS_LIMIT = 21_000L;
+    private static final int EIP_1559_TX_TYPE = 0x02;
+    private static final Duration DEFAULT_WAIT_DURATION = Duration.ofMinutes(5);
+
+    private final EvmRpcClient rpcClient;
+    private final FeeOracle feeOracle;
+    private final long chainId;
+
+    @Override
+    public boolean appliesTo(ChainFamily chainFamily) {
+        return chainFamily == ChainFamily.EVM;
+    }
+
+    @Override
+    public StuckAssessment assess(SubmittedTransaction transaction) {
+        var receipt = rpcClient.getTransactionReceipt(transaction.txHash());
+        if (receipt.isPresent()) {
+            return assessConfirmedTransaction();
+        }
+
+        var mempoolTx = rpcClient.getTransactionByHash(transaction.txHash());
+        if (mempoolTx.isEmpty()) {
+            return assessDroppedTransaction(transaction);
+        }
+
+        var tx = mempoolTx.get();
+        var nonceAssessment = assessNonceGap(transaction, tx);
+        if (nonceAssessment != null) {
+            return nonceAssessment;
+        }
+
+        return assessGasPrice(transaction, tx);
+    }
+
+    @Override
+    public RecoveryResult execute(RecoveryPlan plan, TransactionSigner signer) {
+        return switch (plan) {
+            case RecoveryPlan.SpeedUp speedUp -> executeSpeedUp(speedUp, signer);
+            case RecoveryPlan.Cancel cancel -> executeCancel(cancel, signer);
+            case RecoveryPlan.Resubmit _ -> throw new IllegalStateException(
+                    "EVM does not support Resubmit — use SpeedUp (RBF) instead");
+            case RecoveryPlan.Wait wait -> RecoveryResult.builder()
+                    .outcome(RecoveryOutcome.WAITING)
+                    .details("Waiting estimated %s: %s".formatted(wait.estimatedClearance(), wait.reason()))
+                    .build();
+        };
+    }
+
+    private StuckAssessment assessConfirmedTransaction() {
+        return StuckAssessment.builder()
+                .reason(StuckReason.NOT_SEEN)
+                .severity(StuckSeverity.LOW)
+                .recommendedPlan(RecoveryPlan.Wait.builder()
+                        .estimatedClearance(DEFAULT_WAIT_DURATION)
+                        .reason("Transaction has receipt, may be confirming")
+                        .build())
+                .explanation("Transaction already has receipt on chain")
+                .build();
+    }
+
+    private StuckAssessment assessDroppedTransaction(SubmittedTransaction transaction) {
+        var urgentFee = feeOracle.estimate(transaction.chain(), FeeUrgency.URGENT);
+        return StuckAssessment.builder()
+                .reason(StuckReason.MEMPOOL_DROPPED)
+                .severity(StuckSeverity.HIGH)
+                .recommendedPlan(RecoveryPlan.SpeedUp.builder()
+                        .originalTxHash(transaction.txHash())
+                        .newFee(urgentFee)
+                        .build())
+                .explanation("Transaction not found in mempool and no receipt — likely dropped")
+                .build();
+    }
+
+    private StuckAssessment assessNonceGap(SubmittedTransaction transaction, EvmTransaction tx) {
+        var onChainNonce = rpcClient.getTransactionCount(transaction.fromAddress(), "latest");
+        var txNonce = decodeQuantity(tx.nonce()).longValue();
+
+        if (onChainNonce.longValue() < txNonce) {
+            var replacementFee = feeOracle.estimateReplacement(
+                    transaction.chain(), transaction.txHash(), transaction.retryCount() + 1);
+            return StuckAssessment.builder()
+                    .reason(StuckReason.NONCE_GAP)
+                    .severity(StuckSeverity.HIGH)
+                    .recommendedPlan(RecoveryPlan.SpeedUp.builder()
+                            .originalTxHash(transaction.txHash())
+                            .newFee(replacementFee)
+                            .build())
+                    .explanation("Nonce gap detected: on-chain nonce=%d, transaction nonce=%d"
+                            .formatted(onChainNonce.longValue(), txNonce))
+                    .build();
+        }
+        return null;
+    }
+
+    private StuckAssessment assessGasPrice(SubmittedTransaction transaction, EvmTransaction tx) {
+        var currentFee = feeOracle.estimate(transaction.chain(), FeeUrgency.FAST);
+        var originalMaxFee = decodeMaxFee(tx);
+        var currentMaxFee = currentFee.maxFeePerGas();
+
+        if (currentMaxFee.compareTo(originalMaxFee) > 0) {
+            var replacementFee = feeOracle.estimateReplacement(
+                    transaction.chain(), transaction.txHash(), transaction.retryCount() + 1);
+            var ratio = originalMaxFee.compareTo(BigDecimal.ZERO) > 0
+                    ? currentMaxFee.divide(originalMaxFee, 2, RoundingMode.HALF_UP)
+                    : currentMaxFee;
+            return StuckAssessment.builder()
+                    .reason(StuckReason.UNDERPRICED)
+                    .severity(StuckSeverity.MEDIUM)
+                    .recommendedPlan(RecoveryPlan.SpeedUp.builder()
+                            .originalTxHash(transaction.txHash())
+                            .newFee(replacementFee)
+                            .build())
+                    .explanation("Transaction underpriced: current fast=%s wei, submission=%s wei, ratio=%s"
+                            .formatted(currentMaxFee.toPlainString(), originalMaxFee.toPlainString(),
+                                    ratio.toPlainString()))
+                    .build();
+        }
+
+        return StuckAssessment.builder()
+                .reason(StuckReason.NOT_PROPAGATED)
+                .severity(StuckSeverity.LOW)
+                .recommendedPlan(RecoveryPlan.Wait.builder()
+                        .estimatedClearance(DEFAULT_WAIT_DURATION)
+                        .reason("Transaction in mempool with adequate fee, waiting for inclusion")
+                        .build())
+                .explanation("Transaction in mempool with adequate gas price, pending network inclusion")
+                .build();
+    }
+
+    private RecoveryResult executeSpeedUp(RecoveryPlan.SpeedUp speedUp, TransactionSigner signer) {
+        var originalTx = rpcClient.getTransactionByHash(speedUp.originalTxHash())
+                .orElseThrow(() -> new EvmRpcException(
+                        "Original transaction not found for speed-up: " + speedUp.originalTxHash(), false));
+
+        var nonce = decodeQuantity(originalTx.nonce()).longValue();
+        var toAddress = originalTx.to();
+        var value = decodeQuantity(originalTx.value());
+        var data = decodeData(originalTx.input());
+        var gasLimit = decodeQuantity(originalTx.gas());
+
+        var maxFeePerGas = speedUp.newFee().maxFeePerGas().toBigInteger();
+        var maxPriorityFeePerGas = speedUp.newFee().maxPriorityFeePerGas().toBigInteger();
+
+        var rlpPayload = encodeEip1559Transaction(
+                nonce, maxPriorityFeePerGas, maxFeePerGas, gasLimit, toAddress, value, data);
+
+        var unsignedTx = UnsignedTransaction.builder()
+                .intentId("recovery-speedup-" + speedUp.originalTxHash())
+                .chain(rpcClient.getChain())
+                .fromAddress(originalTx.from())
+                .toAddress(toAddress)
+                .payload(rlpPayload)
+                .feeEstimate(speedUp.newFee())
+                .metadata(Map.of(
+                        "nonce", String.valueOf(nonce),
+                        "gasLimit", gasLimit.toString(),
+                        "type", "0x02",
+                        "chainId", String.valueOf(chainId),
+                        "recoveryAction", "SPEED_UP",
+                        "originalTxHash", speedUp.originalTxHash()))
+                .build();
+
+        var signedTx = signer.sign(unsignedTx, originalTx.from());
+        var txHash = rpcClient.sendRawTransaction(
+                "0x" + HexFormat.of().formatHex(signedTx.signedPayload()));
+
+        return RecoveryResult.builder()
+                .outcome(RecoveryOutcome.REPLACEMENT_SUBMITTED)
+                .replacementTxHash(txHash)
+                .gasCost(speedUp.newFee().estimatedCost())
+                .details("Speed-up replacement submitted with nonce=%d, maxFeePerGas=%s wei"
+                        .formatted(nonce, maxFeePerGas))
+                .build();
+    }
+
+    private RecoveryResult executeCancel(RecoveryPlan.Cancel cancel, TransactionSigner signer) {
+        var originalTx = rpcClient.getTransactionByHash(cancel.originalTxHash())
+                .orElseThrow(() -> new EvmRpcException(
+                        "Original transaction not found for cancel: " + cancel.originalTxHash(), false));
+
+        var nonce = decodeQuantity(originalTx.nonce()).longValue();
+        var fromAddress = originalTx.from();
+
+        var cancelFee = feeOracle.estimate(rpcClient.getChain(), FeeUrgency.FAST);
+        var maxFeePerGas = cancelFee.maxFeePerGas().toBigInteger();
+        var maxPriorityFeePerGas = cancelFee.maxPriorityFeePerGas().toBigInteger();
+
+        var rlpPayload = encodeEip1559Transaction(
+                nonce, maxPriorityFeePerGas, maxFeePerGas, BigInteger.valueOf(CANCEL_GAS_LIMIT),
+                fromAddress, BigInteger.ZERO, new byte[0]);
+
+        var unsignedTx = UnsignedTransaction.builder()
+                .intentId("recovery-cancel-" + cancel.originalTxHash())
+                .chain(rpcClient.getChain())
+                .fromAddress(fromAddress)
+                .toAddress(fromAddress)
+                .payload(rlpPayload)
+                .feeEstimate(cancelFee)
+                .metadata(Map.of(
+                        "nonce", String.valueOf(nonce),
+                        "gasLimit", String.valueOf(CANCEL_GAS_LIMIT),
+                        "type", "0x02",
+                        "chainId", String.valueOf(chainId),
+                        "recoveryAction", "CANCEL",
+                        "originalTxHash", cancel.originalTxHash()))
+                .build();
+
+        var signedTx = signer.sign(unsignedTx, fromAddress);
+        var txHash = rpcClient.sendRawTransaction(
+                "0x" + HexFormat.of().formatHex(signedTx.signedPayload()));
+
+        return RecoveryResult.builder()
+                .outcome(RecoveryOutcome.REPLACEMENT_SUBMITTED)
+                .replacementTxHash(txHash)
+                .gasCost(cancelFee.estimatedCost())
+                .details("Cancel self-transfer submitted with nonce=%d, gasLimit=%d"
+                        .formatted(nonce, CANCEL_GAS_LIMIT))
+                .build();
+    }
+
+    private byte[] encodeEip1559Transaction(
+            long nonce,
+            BigInteger maxPriorityFeePerGas,
+            BigInteger maxFeePerGas,
+            BigInteger gasLimit,
+            String to,
+            BigInteger value,
+            byte[] data) {
+        var toBytes = parseEvmAddress(to);
+
+        List<Object> fields = List.of(
+                BigInteger.valueOf(chainId),
+                BigInteger.valueOf(nonce),
+                maxPriorityFeePerGas,
+                maxFeePerGas,
+                gasLimit,
+                toBytes,
+                value,
+                data,
+                List.of());
+
+        var rlpEncoded = RlpEncoder.encode(fields);
+
+        var output = new ByteArrayOutputStream(1 + rlpEncoded.length);
+        output.write(EIP_1559_TX_TYPE);
+        output.write(rlpEncoded, 0, rlpEncoded.length);
+        return output.toByteArray();
+    }
+
+    private static byte[] parseEvmAddress(String address) {
+        var hex = address.startsWith("0x") ? address.substring(2) : address;
+        return HexFormat.of().parseHex(hex);
+    }
+
+    private static byte[] decodeData(String input) {
+        if (input == null || "0x".equals(input) || input.isEmpty()) {
+            return new byte[0];
+        }
+        var hex = input.startsWith("0x") ? input.substring(2) : input;
+        return HexFormat.of().parseHex(hex);
+    }
+
+    private static BigDecimal decodeMaxFee(EvmTransaction tx) {
+        if (tx.maxFeePerGas() != null) {
+            return new BigDecimal(decodeQuantity(tx.maxFeePerGas()));
+        }
+        if (tx.gasPrice() != null) {
+            return new BigDecimal(decodeQuantity(tx.gasPrice()));
+        }
+        return BigDecimal.ZERO;
+    }
+
+    private static BigInteger decodeQuantity(String hex) {
+        var stripped = hex.startsWith("0x") ? hex.substring(2) : hex;
+        return new BigInteger(stripped, 16);
+    }
+}

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/infrastructure/client/evm/EvmRecoveryStrategyTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/infrastructure/client/evm/EvmRecoveryStrategyTest.java
@@ -1,0 +1,437 @@
+package com.stablebridge.txrecovery.infrastructure.client.evm;
+
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_CHAIN;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_CHAIN_ID;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_FAST_FEE;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_FROM_ADDRESS;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_LOW_FAST_FEE;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_LOW_FEE_MEMPOOL_TRANSACTION;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_MEMPOOL_TRANSACTION;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_RECEIPT;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_REPLACEMENT_FEE;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_REPLACEMENT_TX_HASH;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_TX_HASH;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.SOME_URGENT_FEE;
+import static com.stablebridge.txrecovery.infrastructure.client.evm.EvmRecoveryFixtures.someStuckTransaction;
+import static com.stablebridge.txrecovery.testutil.TestUtils.eqIgnoring;
+import static com.stablebridge.txrecovery.testutil.TestUtils.eqIgnoringTimestamps;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+
+import java.math.BigInteger;
+import java.time.Duration;
+import java.util.Map;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.stablebridge.txrecovery.domain.address.model.ChainFamily;
+import com.stablebridge.txrecovery.domain.recovery.model.FeeUrgency;
+import com.stablebridge.txrecovery.domain.recovery.model.RecoveryOutcome;
+import com.stablebridge.txrecovery.domain.recovery.model.RecoveryPlan;
+import com.stablebridge.txrecovery.domain.recovery.model.RecoveryResult;
+import com.stablebridge.txrecovery.domain.recovery.model.StuckAssessment;
+import com.stablebridge.txrecovery.domain.recovery.model.StuckReason;
+import com.stablebridge.txrecovery.domain.recovery.model.StuckSeverity;
+import com.stablebridge.txrecovery.domain.recovery.port.FeeOracle;
+import com.stablebridge.txrecovery.domain.transaction.model.SignedTransaction;
+import com.stablebridge.txrecovery.domain.transaction.model.UnsignedTransaction;
+import com.stablebridge.txrecovery.domain.transaction.port.TransactionSigner;
+
+@ExtendWith(MockitoExtension.class)
+class EvmRecoveryStrategyTest {
+
+    @Mock
+    private EvmRpcClient rpcClient;
+
+    @Mock
+    private FeeOracle feeOracle;
+
+    @Mock
+    private TransactionSigner signer;
+
+    private EvmRecoveryStrategy strategy;
+
+    @BeforeEach
+    void setUp() {
+        strategy = new EvmRecoveryStrategy(rpcClient, feeOracle, SOME_CHAIN_ID);
+    }
+
+    @Nested
+    class AppliesTo {
+
+        @Test
+        void shouldReturnTrueForEvm() {
+            // when
+            var result = strategy.appliesTo(ChainFamily.EVM);
+
+            // then
+            assertThat(result).isTrue();
+        }
+
+        @Test
+        void shouldReturnFalseForSolana() {
+            // when
+            var result = strategy.appliesTo(ChainFamily.SOLANA);
+
+            // then
+            assertThat(result).isFalse();
+        }
+    }
+
+    @Nested
+    class Assess {
+
+        @Nested
+        class WhenTransactionHasReceipt {
+
+            @Test
+            void shouldReturnWaitWithNotSeenReason() {
+                // given
+                var transaction = someStuckTransaction();
+                given(rpcClient.getTransactionReceipt(SOME_TX_HASH))
+                        .willReturn(Optional.of(SOME_RECEIPT));
+
+                // when
+                var result = strategy.assess(transaction);
+
+                // then
+                var expected = StuckAssessment.builder()
+                        .reason(StuckReason.NOT_SEEN)
+                        .severity(StuckSeverity.LOW)
+                        .recommendedPlan(RecoveryPlan.Wait.builder()
+                                .estimatedClearance(Duration.ofMinutes(5))
+                                .reason("Transaction has receipt, may be confirming")
+                                .build())
+                        .explanation("Transaction already has receipt on chain")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        class WhenTransactionDroppedFromMempool {
+
+            @Test
+            void shouldReturnMempoolDroppedWithSpeedUpPlan() {
+                // given
+                var transaction = someStuckTransaction();
+                given(rpcClient.getTransactionReceipt(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+                given(feeOracle.estimate(SOME_CHAIN, FeeUrgency.URGENT))
+                        .willReturn(SOME_URGENT_FEE);
+
+                // when
+                var result = strategy.assess(transaction);
+
+                // then
+                var expected = StuckAssessment.builder()
+                        .reason(StuckReason.MEMPOOL_DROPPED)
+                        .severity(StuckSeverity.HIGH)
+                        .recommendedPlan(RecoveryPlan.SpeedUp.builder()
+                                .originalTxHash(SOME_TX_HASH)
+                                .newFee(SOME_URGENT_FEE)
+                                .build())
+                        .explanation("Transaction not found in mempool and no receipt — likely dropped")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        class WhenNonceGapDetected {
+
+            @Test
+            void shouldReturnNonceGapWithHighSeverity() {
+                // given
+                var transaction = someStuckTransaction();
+                given(rpcClient.getTransactionReceipt(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.of(SOME_MEMPOOL_TRANSACTION));
+                given(rpcClient.getTransactionCount(SOME_FROM_ADDRESS, "latest"))
+                        .willReturn(BigInteger.valueOf(3));
+                given(feeOracle.estimateReplacement(SOME_CHAIN, SOME_TX_HASH, 1))
+                        .willReturn(SOME_REPLACEMENT_FEE);
+
+                // when
+                var result = strategy.assess(transaction);
+
+                // then
+                var expected = StuckAssessment.builder()
+                        .reason(StuckReason.NONCE_GAP)
+                        .severity(StuckSeverity.HIGH)
+                        .recommendedPlan(RecoveryPlan.SpeedUp.builder()
+                                .originalTxHash(SOME_TX_HASH)
+                                .newFee(SOME_REPLACEMENT_FEE)
+                                .build())
+                        .explanation("Nonce gap detected: on-chain nonce=3, transaction nonce=5")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        class WhenTransactionUnderpriced {
+
+            @Test
+            void shouldReturnUnderpricedWithMediumSeverity() {
+                // given
+                var transaction = someStuckTransaction();
+                given(rpcClient.getTransactionReceipt(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.of(SOME_LOW_FEE_MEMPOOL_TRANSACTION));
+                given(rpcClient.getTransactionCount(SOME_FROM_ADDRESS, "latest"))
+                        .willReturn(BigInteger.valueOf(5));
+                given(feeOracle.estimate(SOME_CHAIN, FeeUrgency.FAST))
+                        .willReturn(SOME_FAST_FEE);
+                given(feeOracle.estimateReplacement(SOME_CHAIN, SOME_TX_HASH, 1))
+                        .willReturn(SOME_REPLACEMENT_FEE);
+
+                // when
+                var result = strategy.assess(transaction);
+
+                // then
+                var expected = StuckAssessment.builder()
+                        .reason(StuckReason.UNDERPRICED)
+                        .severity(StuckSeverity.MEDIUM)
+                        .recommendedPlan(RecoveryPlan.SpeedUp.builder()
+                                .originalTxHash(SOME_TX_HASH)
+                                .newFee(SOME_REPLACEMENT_FEE)
+                                .build())
+                        .explanation(
+                                "Transaction underpriced: current fast=30000000000 wei, submission=5000000000 wei, ratio=6.00")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+        }
+
+        @Nested
+        class WhenTransactionHasAdequateGas {
+
+            @Test
+            void shouldReturnNotPropagatedWithWaitPlan() {
+                // given
+                var transaction = someStuckTransaction();
+                given(rpcClient.getTransactionReceipt(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.of(SOME_MEMPOOL_TRANSACTION));
+                given(rpcClient.getTransactionCount(SOME_FROM_ADDRESS, "latest"))
+                        .willReturn(BigInteger.valueOf(5));
+                given(feeOracle.estimate(SOME_CHAIN, FeeUrgency.FAST))
+                        .willReturn(SOME_LOW_FAST_FEE);
+
+                // when
+                var result = strategy.assess(transaction);
+
+                // then
+                var expected = StuckAssessment.builder()
+                        .reason(StuckReason.NOT_PROPAGATED)
+                        .severity(StuckSeverity.LOW)
+                        .recommendedPlan(RecoveryPlan.Wait.builder()
+                                .estimatedClearance(Duration.ofMinutes(5))
+                                .reason("Transaction in mempool with adequate fee, waiting for inclusion")
+                                .build())
+                        .explanation("Transaction in mempool with adequate gas price, pending network inclusion")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+        }
+    }
+
+    @Nested
+    class Execute {
+
+        @Nested
+        class SpeedUp {
+
+            @Test
+            void shouldBuildReplacementAndBroadcast() {
+                // given
+                var plan = RecoveryPlan.SpeedUp.builder()
+                        .originalTxHash(SOME_TX_HASH)
+                        .newFee(SOME_REPLACEMENT_FEE)
+                        .build();
+                var signedTx = SignedTransaction.builder()
+                        .intentId("recovery-speedup-" + SOME_TX_HASH)
+                        .chain(SOME_CHAIN)
+                        .signedPayload(new byte[] {0x01, 0x02, 0x03})
+                        .signerAddress(SOME_FROM_ADDRESS)
+                        .build();
+                var expectedUnsigned = UnsignedTransaction.builder()
+                        .intentId("recovery-speedup-" + SOME_TX_HASH)
+                        .chain(SOME_CHAIN)
+                        .fromAddress(SOME_FROM_ADDRESS)
+                        .toAddress(SOME_MEMPOOL_TRANSACTION.to())
+                        .payload(new byte[] {0})
+                        .feeEstimate(SOME_REPLACEMENT_FEE)
+                        .metadata(Map.of(
+                                "nonce", "5",
+                                "gasLimit", "65000",
+                                "type", "0x02",
+                                "chainId", "1",
+                                "recoveryAction", "SPEED_UP",
+                                "originalTxHash", SOME_TX_HASH))
+                        .build();
+
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.of(SOME_MEMPOOL_TRANSACTION));
+                given(rpcClient.getChain()).willReturn(SOME_CHAIN);
+                given(signer.sign(eqIgnoring(expectedUnsigned, "payload"), eqIgnoringTimestamps(SOME_FROM_ADDRESS)))
+                        .willReturn(signedTx);
+                given(rpcClient.sendRawTransaction("0x010203"))
+                        .willReturn(SOME_REPLACEMENT_TX_HASH);
+
+                // when
+                var result = strategy.execute(plan, signer);
+
+                // then
+                var expected = RecoveryResult.builder()
+                        .outcome(RecoveryOutcome.REPLACEMENT_SUBMITTED)
+                        .replacementTxHash(SOME_REPLACEMENT_TX_HASH)
+                        .gasCost(SOME_REPLACEMENT_FEE.estimatedCost())
+                        .details("Speed-up replacement submitted with nonce=5, maxFeePerGas=55000000000 wei")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+
+            @Test
+            void shouldThrowWhenOriginalTransactionNotFound() {
+                // given
+                var plan = RecoveryPlan.SpeedUp.builder()
+                        .originalTxHash(SOME_TX_HASH)
+                        .newFee(SOME_REPLACEMENT_FEE)
+                        .build();
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+
+                // when/then
+                assertThatThrownBy(() -> strategy.execute(plan, signer))
+                        .isInstanceOf(EvmRpcException.class)
+                        .hasMessageContaining("Original transaction not found for speed-up");
+            }
+        }
+
+        @Nested
+        class Cancel {
+
+            @Test
+            void shouldBuildSelfTransferAndBroadcast() {
+                // given
+                var plan = RecoveryPlan.Cancel.builder()
+                        .originalTxHash(SOME_TX_HASH)
+                        .build();
+                var signedTx = SignedTransaction.builder()
+                        .intentId("recovery-cancel-" + SOME_TX_HASH)
+                        .chain(SOME_CHAIN)
+                        .signedPayload(new byte[] {0x04, 0x05, 0x06})
+                        .signerAddress(SOME_FROM_ADDRESS)
+                        .build();
+                var expectedUnsigned = UnsignedTransaction.builder()
+                        .intentId("recovery-cancel-" + SOME_TX_HASH)
+                        .chain(SOME_CHAIN)
+                        .fromAddress(SOME_FROM_ADDRESS)
+                        .toAddress(SOME_FROM_ADDRESS)
+                        .payload(new byte[] {0})
+                        .feeEstimate(SOME_FAST_FEE)
+                        .metadata(Map.of(
+                                "nonce", "5",
+                                "gasLimit", "21000",
+                                "type", "0x02",
+                                "chainId", "1",
+                                "recoveryAction", "CANCEL",
+                                "originalTxHash", SOME_TX_HASH))
+                        .build();
+
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.of(SOME_MEMPOOL_TRANSACTION));
+                given(rpcClient.getChain()).willReturn(SOME_CHAIN);
+                given(feeOracle.estimate(SOME_CHAIN, FeeUrgency.FAST))
+                        .willReturn(SOME_FAST_FEE);
+                given(signer.sign(eqIgnoring(expectedUnsigned, "payload"), eqIgnoringTimestamps(SOME_FROM_ADDRESS)))
+                        .willReturn(signedTx);
+                given(rpcClient.sendRawTransaction("0x040506"))
+                        .willReturn(SOME_REPLACEMENT_TX_HASH);
+
+                // when
+                var result = strategy.execute(plan, signer);
+
+                // then
+                var expected = RecoveryResult.builder()
+                        .outcome(RecoveryOutcome.REPLACEMENT_SUBMITTED)
+                        .replacementTxHash(SOME_REPLACEMENT_TX_HASH)
+                        .gasCost(SOME_FAST_FEE.estimatedCost())
+                        .details("Cancel self-transfer submitted with nonce=5, gasLimit=21000")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+            }
+
+            @Test
+            void shouldThrowWhenOriginalTransactionNotFound() {
+                // given
+                var plan = RecoveryPlan.Cancel.builder()
+                        .originalTxHash(SOME_TX_HASH)
+                        .build();
+                given(rpcClient.getTransactionByHash(SOME_TX_HASH))
+                        .willReturn(Optional.empty());
+
+                // when/then
+                assertThatThrownBy(() -> strategy.execute(plan, signer))
+                        .isInstanceOf(EvmRpcException.class)
+                        .hasMessageContaining("Original transaction not found for cancel");
+            }
+        }
+
+        @Nested
+        class Resubmit {
+
+            @Test
+            void shouldThrowIllegalStateException() {
+                // given
+                var plan = RecoveryPlan.Resubmit.builder()
+                        .originalTxHash(SOME_TX_HASH)
+                        .build();
+
+                // when/then
+                assertThatThrownBy(() -> strategy.execute(plan, signer))
+                        .isInstanceOf(IllegalStateException.class)
+                        .hasMessageContaining("EVM does not support Resubmit");
+            }
+        }
+
+        @Nested
+        class Wait {
+
+            @Test
+            void shouldReturnWaitingResult() {
+                // given
+                var plan = RecoveryPlan.Wait.builder()
+                        .estimatedClearance(Duration.ofMinutes(10))
+                        .reason("Network congestion clearing")
+                        .build();
+
+                // when
+                var result = strategy.execute(plan, signer);
+
+                // then
+                var expected = RecoveryResult.builder()
+                        .outcome(RecoveryOutcome.WAITING)
+                        .details("Waiting estimated PT10M: Network congestion clearing")
+                        .build();
+                assertThat(result).usingRecursiveComparison().isEqualTo(expected);
+                then(signer).shouldHaveNoInteractions();
+            }
+        }
+    }
+}

--- a/stablebridge-tx-recovery/src/testFixtures/java/com/stablebridge/txrecovery/infrastructure/client/evm/EvmRecoveryFixtures.java
+++ b/stablebridge-tx-recovery/src/testFixtures/java/com/stablebridge/txrecovery/infrastructure/client/evm/EvmRecoveryFixtures.java
@@ -1,0 +1,115 @@
+package com.stablebridge.txrecovery.infrastructure.client.evm;
+
+import static lombok.AccessLevel.PRIVATE;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+
+import com.stablebridge.txrecovery.domain.recovery.model.FeeEstimate;
+import com.stablebridge.txrecovery.domain.recovery.model.FeeUrgency;
+import com.stablebridge.txrecovery.domain.transaction.model.SubmittedTransaction;
+import com.stablebridge.txrecovery.domain.transaction.model.TransactionStatus;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = PRIVATE)
+public final class EvmRecoveryFixtures {
+
+    public static final String SOME_TX_HASH = "0xabc123def456";
+    public static final String SOME_FROM_ADDRESS = "0x1111111111111111111111111111111111111111";
+    public static final String SOME_TO_ADDRESS = "0x2222222222222222222222222222222222222222";
+    public static final String SOME_CHAIN = "ethereum";
+    public static final long SOME_CHAIN_ID = 1L;
+    public static final String SOME_REPLACEMENT_TX_HASH = "0xnew789abc";
+    public static final BigDecimal SOME_GAS_BUDGET = new BigDecimal("0.01");
+
+    public static final FeeEstimate SOME_URGENT_FEE = FeeEstimate.builder()
+            .maxFeePerGas(new BigDecimal("50000000000"))
+            .maxPriorityFeePerGas(new BigDecimal("5000000000"))
+            .estimatedCost(new BigDecimal("50000000000"))
+            .denomination("wei")
+            .urgency(FeeUrgency.URGENT)
+            .details(Map.of("source", "urgent-estimate"))
+            .build();
+
+    public static final FeeEstimate SOME_FAST_FEE = FeeEstimate.builder()
+            .maxFeePerGas(new BigDecimal("30000000000"))
+            .maxPriorityFeePerGas(new BigDecimal("3000000000"))
+            .estimatedCost(new BigDecimal("30000000000"))
+            .denomination("wei")
+            .urgency(FeeUrgency.FAST)
+            .details(Map.of("source", "fast-estimate"))
+            .build();
+
+    public static final FeeEstimate SOME_LOW_FAST_FEE = FeeEstimate.builder()
+            .maxFeePerGas(new BigDecimal("5000000000"))
+            .maxPriorityFeePerGas(new BigDecimal("1000000000"))
+            .estimatedCost(new BigDecimal("5000000000"))
+            .denomination("wei")
+            .urgency(FeeUrgency.FAST)
+            .details(Map.of("source", "low-fast-estimate"))
+            .build();
+
+    public static final FeeEstimate SOME_REPLACEMENT_FEE = FeeEstimate.builder()
+            .maxFeePerGas(new BigDecimal("55000000000"))
+            .maxPriorityFeePerGas(new BigDecimal("5500000000"))
+            .estimatedCost(new BigDecimal("55000000000"))
+            .denomination("wei")
+            .urgency(FeeUrgency.URGENT)
+            .details(Map.of("source", "replacement-estimate"))
+            .build();
+
+    public static final EvmTransaction SOME_MEMPOOL_TRANSACTION = EvmTransaction.builder()
+            .hash(SOME_TX_HASH)
+            .nonce("0x5")
+            .from(SOME_FROM_ADDRESS)
+            .to(SOME_TO_ADDRESS)
+            .value("0x0")
+            .gas("0xfde8")
+            .maxFeePerGas("0x6fc23ac00")
+            .maxPriorityFeePerGas("0x77359400")
+            .input("0xa9059cbb")
+            .type("0x2")
+            .build();
+
+    public static final EvmTransaction SOME_LOW_FEE_MEMPOOL_TRANSACTION = EvmTransaction.builder()
+            .hash(SOME_TX_HASH)
+            .nonce("0x5")
+            .from(SOME_FROM_ADDRESS)
+            .to(SOME_TO_ADDRESS)
+            .value("0x0")
+            .gas("0xfde8")
+            .maxFeePerGas("0x12a05f200")
+            .maxPriorityFeePerGas("0x3b9aca00")
+            .input("0xa9059cbb")
+            .type("0x2")
+            .build();
+
+    public static final EvmReceipt SOME_RECEIPT = EvmReceipt.builder()
+            .transactionHash(SOME_TX_HASH)
+            .blockNumber("0xa")
+            .status("0x1")
+            .gasUsed("0x5208")
+            .effectiveGasPrice("0x6fc23ac00")
+            .build();
+
+    public static SubmittedTransaction someStuckTransaction() {
+        return SubmittedTransaction.builder()
+                .transactionId("tx-001")
+                .intentId("intent-001")
+                .chain(SOME_CHAIN)
+                .txHash(SOME_TX_HASH)
+                .fromAddress(SOME_FROM_ADDRESS)
+                .status(TransactionStatus.STUCK)
+                .retryCount(0)
+                .gasSpent(BigDecimal.ZERO)
+                .gasDenomination("wei")
+                .gasBudget(SOME_GAS_BUDGET)
+                .recoveryHistory(List.of())
+                .submittedAt(Instant.parse("2026-03-27T10:00:00Z"))
+                .stuckSince(Instant.parse("2026-03-27T10:05:00Z"))
+                .build();
+    }
+}


### PR DESCRIPTION
## Summary
- Implement `EvmRecoveryStrategy` as the EVM adapter for the `RecoveryStrategy` port
- `assess()` classifies stuck transactions: UNDERPRICED (gas ratio), NONCE_GAP (on-chain vs tx nonce), MEMPOOL_DROPPED (not in mempool), NOT_PROPAGATED (adequate gas, waiting)
- `execute()` handles SpeedUp (RBF with same nonce/to/value/data, higher gas), Cancel (zero-value self-transfer, gasLimit=21000), Wait (no-op), and rejects Resubmit (EVM uses RBF)
- Replacement fees enforce 10% minimum bump via `FeeOracle.estimateReplacement()`
- `RecoveryResult` includes replacementTxHash, gasCost, and outcome

## Test plan
- [x] Unit tests for `appliesTo()` — EVM returns true, SOLANA returns false
- [x] Unit tests for `assess()` — all 4 scenarios: receipt present, mempool dropped, nonce gap, underpriced, adequate gas
- [x] Unit tests for `execute(SpeedUp)` — builds replacement tx, signs, broadcasts, returns result
- [x] Unit tests for `execute(Cancel)` — builds self-transfer, gasLimit=21000, signs, broadcasts
- [x] Unit tests for `execute(Resubmit)` — throws IllegalStateException
- [x] Unit tests for `execute(Wait)` — returns WAITING result, no signer interaction
- [x] Build passes with spotless + all tests green

Closes #18

🤖 Generated with [Claude Code](https://claude.com/claude-code)