### PR TITLE
STR-25: add LocalKeystoreSigner with ECDSA secp256k1 and EdDSA Ed25519 signing

### DIFF
--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/exception/SignatureComputationException.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/exception/SignatureComputationException.java
@@ -1,0 +1,12 @@
+package com.stablebridge.txrecovery.domain.exception;
+
+public class SignatureComputationException extends StrException {
+
+    public SignatureComputationException(String detail) {
+        super("STR-5031", "Signature computation failed: %s".formatted(detail));
+    }
+
+    public SignatureComputationException(String detail, Throwable cause) {
+        super("STR-5031", "Signature computation failed: %s".formatted(detail), cause);
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/exception/SignerKeyNotFoundException.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/exception/SignerKeyNotFoundException.java
@@ -1,0 +1,8 @@
+package com.stablebridge.txrecovery.domain.exception;
+
+public class SignerKeyNotFoundException extends StrException {
+
+    public SignerKeyNotFoundException(String address) {
+        super("STR-5030", "No private key found for address: %s".formatted(address));
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/LocalKeystoreSigner.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/LocalKeystoreSigner.java
@@ -3,16 +3,22 @@ package com.stablebridge.txrecovery.infrastructure.signer;
 import java.math.BigInteger;
 import java.util.Locale;
 import java.util.Map;
+import java.util.stream.Collectors;
 
+import org.bouncycastle.asn1.x9.X9ECParameters;
+import org.bouncycastle.crypto.digests.SHA256Digest;
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
 import org.bouncycastle.crypto.params.ECDomainParameters;
 import org.bouncycastle.crypto.params.ECPrivateKeyParameters;
 import org.bouncycastle.crypto.signers.ECDSASigner;
+import org.bouncycastle.crypto.signers.HMacDSAKCalculator;
 import org.bouncycastle.jcajce.provider.digest.Keccak;
 import org.bouncycastle.math.ec.ECCurve;
 import org.bouncycastle.math.ec.ECPoint;
 import org.bouncycastle.math.ec.rfc8032.Ed25519;
 
+import com.stablebridge.txrecovery.domain.exception.SignatureComputationException;
+import com.stablebridge.txrecovery.domain.exception.SignerKeyNotFoundException;
 import com.stablebridge.txrecovery.domain.transaction.model.SignedTransaction;
 import com.stablebridge.txrecovery.domain.transaction.model.UnsignedTransaction;
 import com.stablebridge.txrecovery.domain.transaction.port.TransactionSigner;
@@ -20,24 +26,31 @@ import com.stablebridge.txrecovery.domain.transaction.port.TransactionSigner;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
-class LocalKeystoreSigner implements TransactionSigner {
+public class LocalKeystoreSigner implements TransactionSigner {
 
     private static final int ECDSA_SIGNATURE_LENGTH = 65;
     private static final int ED25519_SIGNATURE_LENGTH = 64;
     private static final int KEY_SIZE_32 = 32;
     private static final int ETHEREUM_V_OFFSET = 27;
+    private static final byte[] SOLANA_SINGLE_SIG_COUNT = {0x01};
+
+    private static final X9ECParameters EC_PARAMS = CustomNamedCurves.getByName("secp256k1");
+    private static final ECDomainParameters DOMAIN_PARAMS = new ECDomainParameters(
+            EC_PARAMS.getCurve(), EC_PARAMS.getG(), EC_PARAMS.getN(), EC_PARAMS.getH());
+    private static final BigInteger HALF_N = EC_PARAMS.getN().shiftRight(1);
 
     private final Map<String, byte[]> privateKeys;
 
-    LocalKeystoreSigner(Map<String, byte[]> privateKeys) {
-        this.privateKeys = Map.copyOf(privateKeys);
+    public LocalKeystoreSigner(Map<String, byte[]> privateKeys) {
+        this.privateKeys = privateKeys.entrySet().stream()
+                .collect(Collectors.toUnmodifiableMap(Map.Entry::getKey, e -> e.getValue().clone()));
     }
 
     @Override
     public SignedTransaction sign(UnsignedTransaction transaction, String fromAddress) {
         var privateKey = privateKeys.get(fromAddress);
         if (privateKey == null) {
-            throw new IllegalArgumentException("No private key found for address: " + fromAddress);
+            throw new SignerKeyNotFoundException(fromAddress);
         }
 
         var signedPayload = isSolanaChain(transaction.chain())
@@ -60,29 +73,24 @@ class LocalKeystoreSigner implements TransactionSigner {
     }
 
     private static byte[] signEcdsa(byte[] payload, byte[] privateKeyBytes) {
-        var ecParams = CustomNamedCurves.getByName("secp256k1");
-        var domainParams = new ECDomainParameters(
-                ecParams.getCurve(), ecParams.getG(), ecParams.getN(), ecParams.getH());
-
         var d = new BigInteger(1, privateKeyBytes);
-        var privateKeyParam = new ECPrivateKeyParameters(d, domainParams);
+        var privateKeyParam = new ECPrivateKeyParameters(d, DOMAIN_PARAMS);
 
         var digest = new Keccak.Digest256();
         var hash = digest.digest(payload);
 
-        var signer = new ECDSASigner();
+        var signer = new ECDSASigner(new HMacDSAKCalculator(new SHA256Digest()));
         signer.init(true, privateKeyParam);
         var components = signer.generateSignature(hash);
         var r = components[0];
         var s = components[1];
 
-        var halfN = ecParams.getN().shiftRight(1);
-        if (s.compareTo(halfN) > 0) {
-            s = ecParams.getN().subtract(s);
+        if (s.compareTo(HALF_N) > 0) {
+            s = EC_PARAMS.getN().subtract(s);
         }
 
-        var publicKeyPoint = ecParams.getG().multiply(d).normalize();
-        var recId = computeRecoveryId(domainParams, r, s, hash, publicKeyPoint);
+        var publicKeyPoint = EC_PARAMS.getG().multiply(d).normalize();
+        var recId = computeRecoveryId(r, s, hash, publicKeyPoint);
 
         var result = new byte[ECDSA_SIGNATURE_LENGTH];
         encodeBigInteger(r, result, 0);
@@ -96,18 +104,18 @@ class LocalKeystoreSigner implements TransactionSigner {
         var signature = new byte[ED25519_SIGNATURE_LENGTH];
         Ed25519.sign(privateKey, 0, payload, 0, payload.length, signature, 0);
 
-        var result = new byte[ED25519_SIGNATURE_LENGTH + payload.length];
-        System.arraycopy(signature, 0, result, 0, ED25519_SIGNATURE_LENGTH);
-        System.arraycopy(payload, 0, result, ED25519_SIGNATURE_LENGTH, payload.length);
+        var result = new byte[SOLANA_SINGLE_SIG_COUNT.length + ED25519_SIGNATURE_LENGTH + payload.length];
+        System.arraycopy(SOLANA_SINGLE_SIG_COUNT, 0, result, 0, SOLANA_SINGLE_SIG_COUNT.length);
+        System.arraycopy(signature, 0, result, SOLANA_SINGLE_SIG_COUNT.length, ED25519_SIGNATURE_LENGTH);
+        System.arraycopy(payload, 0, result, SOLANA_SINGLE_SIG_COUNT.length + ED25519_SIGNATURE_LENGTH, payload.length);
 
         return result;
     }
 
-    private static int computeRecoveryId(
-            ECDomainParameters domain, BigInteger r, BigInteger s, byte[] hash, ECPoint publicKey) {
-        var n = domain.getN();
+    private static int computeRecoveryId(BigInteger r, BigInteger s, byte[] hash, ECPoint publicKey) {
+        var n = DOMAIN_PARAMS.getN();
         var e = new BigInteger(1, hash);
-        var prime = domain.getCurve().getField().getCharacteristic();
+        var prime = DOMAIN_PARAMS.getCurve().getField().getCharacteristic();
 
         for (var recId = 0; recId < 4; recId++) {
             var x = r.add(BigInteger.valueOf(recId / 2).multiply(n));
@@ -115,14 +123,14 @@ class LocalKeystoreSigner implements TransactionSigner {
                 continue;
             }
 
-            var rPoint = decompressPoint(domain.getCurve(), x, (recId & 1) == 1);
+            var rPoint = decompressPoint(DOMAIN_PARAMS.getCurve(), x, (recId & 1) == 1);
             if (!rPoint.multiply(n).isInfinity()) {
                 continue;
             }
 
             var rInv = r.modInverse(n);
             var recovered = rPoint.multiply(s)
-                    .subtract(domain.getG().multiply(e))
+                    .subtract(DOMAIN_PARAMS.getG().multiply(e))
                     .multiply(rInv)
                     .normalize();
 
@@ -131,7 +139,7 @@ class LocalKeystoreSigner implements TransactionSigner {
             }
         }
 
-        throw new IllegalStateException("Could not compute ECDSA recovery id");
+        throw new SignatureComputationException("Could not compute ECDSA recovery id");
     }
 
     private static ECPoint decompressPoint(ECCurve curve, BigInteger x, boolean yOdd) {
@@ -143,12 +151,12 @@ class LocalKeystoreSigner implements TransactionSigner {
 
     private static void encodeBigInteger(BigInteger value, byte[] dest, int offset) {
         var bytes = value.toByteArray();
-        if (bytes.length == KEY_SIZE_32) {
-            System.arraycopy(bytes, 0, dest, offset, KEY_SIZE_32);
-        } else if (bytes.length > KEY_SIZE_32) {
-            System.arraycopy(bytes, bytes.length - KEY_SIZE_32, dest, offset, KEY_SIZE_32);
-        } else {
+        if (bytes[0] == 0 && bytes.length > 1) {
+            System.arraycopy(bytes, 1, dest, offset + KEY_SIZE_32 - (bytes.length - 1), bytes.length - 1);
+        } else if (bytes.length <= KEY_SIZE_32) {
             System.arraycopy(bytes, 0, dest, offset + KEY_SIZE_32 - bytes.length, bytes.length);
+        } else {
+            System.arraycopy(bytes, bytes.length - KEY_SIZE_32, dest, offset, KEY_SIZE_32);
         }
     }
 }

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/LocalSignerConfig.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/LocalSignerConfig.java
@@ -1,0 +1,19 @@
+package com.stablebridge.txrecovery.infrastructure.signer;
+
+import java.util.Map;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.stablebridge.txrecovery.domain.transaction.port.TransactionSigner;
+
+@Configuration
+@EnableConfigurationProperties(LocalSignerProperties.class)
+class LocalSignerConfig {
+
+    @Bean
+    TransactionSigner localKeystoreSigner(LocalSignerProperties properties) {
+        return new LocalKeystoreSigner(Map.of());
+    }
+}

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/LocalSignerProperties.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/LocalSignerProperties.java
@@ -1,8 +1,11 @@
 package com.stablebridge.txrecovery.infrastructure.signer;
 
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
 import lombok.Builder;
 
 @Builder(toBuilder = true)
+@ConfigurationProperties(prefix = "str.signer")
 public record LocalSignerProperties(
         String keystorePath,
         String password) {

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/infrastructure/signer/LocalKeystoreSignerTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/infrastructure/signer/LocalKeystoreSignerTest.java
@@ -1,12 +1,17 @@
 package com.stablebridge.txrecovery.infrastructure.signer;
 
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.SOME_EVM_ADDRESS;
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.SOME_EVM_CHAIN;
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.SOME_INTENT_ID;
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.SOME_PAYLOAD;
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.SOME_SOLANA_ADDRESS;
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.SOME_SOLANA_CHAIN;
+import static com.stablebridge.txrecovery.testutil.fixtures.SignerFixtures.someUnsignedTransaction;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.security.SecureRandom;
-import java.util.HexFormat;
 import java.util.Map;
 
 import org.bouncycastle.crypto.ec.CustomNamedCurves;
@@ -20,19 +25,10 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 
-import com.stablebridge.txrecovery.domain.recovery.model.FeeEstimate;
-import com.stablebridge.txrecovery.domain.recovery.model.FeeUrgency;
+import com.stablebridge.txrecovery.domain.exception.SignerKeyNotFoundException;
 import com.stablebridge.txrecovery.domain.transaction.model.SignedTransaction;
-import com.stablebridge.txrecovery.domain.transaction.model.UnsignedTransaction;
 
 class LocalKeystoreSignerTest {
-
-    private static final String SOME_EVM_ADDRESS = "0xTestEvmAddress";
-    private static final String SOME_SOLANA_ADDRESS = "solana-test-address";
-    private static final String SOME_INTENT_ID = "intent-123";
-    private static final String SOME_EVM_CHAIN = "ethereum";
-    private static final String SOME_SOLANA_CHAIN = "solana-mainnet";
-    private static final byte[] SOME_PAYLOAD = {0x01, 0x02, 0x03, 0x04};
 
     private static byte[] ed25519PrivateKey;
     private static byte[] ed25519PublicKey;
@@ -82,7 +78,7 @@ class LocalKeystoreSignerTest {
         @Test
         void shouldSignTransactionWithSecp256k1() {
             // given
-            var transaction = buildUnsignedTransaction(SOME_INTENT_ID, SOME_EVM_CHAIN);
+            var transaction = someUnsignedTransaction(SOME_INTENT_ID, SOME_EVM_CHAIN);
 
             // when
             var result = signer.sign(transaction, SOME_EVM_ADDRESS);
@@ -106,17 +102,31 @@ class LocalKeystoreSignerTest {
         }
 
         @Test
-        void shouldProduceValidKeccakHash() {
+        void shouldProduceLowSSignature() {
             // given
-            var transaction = buildUnsignedTransaction(SOME_INTENT_ID, SOME_EVM_CHAIN);
+            var transaction = someUnsignedTransaction(SOME_INTENT_ID, SOME_EVM_CHAIN);
+
+            // when
+            var result = signer.sign(transaction, SOME_EVM_ADDRESS);
+
+            // then
+            var s = new BigInteger(1, result.signedPayload(), 32, 32);
+            var halfN = CustomNamedCurves.getByName("secp256k1").getN().shiftRight(1);
+            assertThat(s).isLessThanOrEqualTo(halfN);
+        }
+
+        @Test
+        void shouldSignNonSolanaChainWithEcdsa() {
+            // given
+            var transaction = someUnsignedTransaction(SOME_INTENT_ID, "polygon");
 
             // when
             var result = signer.sign(transaction, SOME_EVM_ADDRESS);
 
             // then
             assertThat(result.signedPayload()).hasSize(65);
-            var txHash = "0x" + HexFormat.of().formatHex(new Keccak.Digest256().digest(result.signedPayload()));
-            assertThat(txHash).startsWith("0x").hasSize(66);
+            var v = result.signedPayload()[64] & 0xFF;
+            assertThat(v).isBetween(27, 28);
         }
     }
 
@@ -126,7 +136,7 @@ class LocalKeystoreSignerTest {
         @Test
         void shouldSignTransactionWithEd25519() {
             // given
-            var transaction = buildUnsignedTransaction(SOME_INTENT_ID, SOME_SOLANA_CHAIN);
+            var transaction = someUnsignedTransaction(SOME_INTENT_ID, SOME_SOLANA_CHAIN);
 
             // when
             var result = signer.sign(transaction, SOME_SOLANA_ADDRESS);
@@ -141,24 +151,22 @@ class LocalKeystoreSignerTest {
             assertThat(result).usingRecursiveComparison().isEqualTo(expected);
 
             var signature = new byte[64];
-            System.arraycopy(result.signedPayload(), 0, signature, 0, 64);
+            System.arraycopy(result.signedPayload(), 1, signature, 0, 64);
             assertThat(Ed25519.verify(signature, 0, ed25519PublicKey, 0,
                     SOME_PAYLOAD, 0, SOME_PAYLOAD.length)).isTrue();
         }
 
         @Test
-        void shouldProduceValidSignature() {
+        void shouldPrependSignatureCountByte() {
             // given
-            var transaction = buildUnsignedTransaction(SOME_INTENT_ID, SOME_SOLANA_CHAIN);
+            var transaction = someUnsignedTransaction(SOME_INTENT_ID, SOME_SOLANA_CHAIN);
 
             // when
             var result = signer.sign(transaction, SOME_SOLANA_ADDRESS);
 
             // then
-            assertThat(result.signedPayload()).hasSize(64 + SOME_PAYLOAD.length);
-            var signature = new byte[64];
-            System.arraycopy(result.signedPayload(), 0, signature, 0, 64);
-            assertThat(signature).hasSize(64);
+            assertThat(result.signedPayload()).hasSize(1 + 64 + SOME_PAYLOAD.length);
+            assertThat(result.signedPayload()[0]).isEqualTo((byte) 0x01);
         }
     }
 
@@ -168,28 +176,13 @@ class LocalKeystoreSignerTest {
         @Test
         void shouldThrowWhenAddressNotFound() {
             // given
-            var transaction = buildUnsignedTransaction(SOME_INTENT_ID, SOME_EVM_CHAIN);
+            var transaction = someUnsignedTransaction(SOME_INTENT_ID, SOME_EVM_CHAIN);
             var unknownAddress = "0xUnknownAddress";
 
             // when/then
             assertThatThrownBy(() -> signer.sign(transaction, unknownAddress))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(SignerKeyNotFoundException.class)
                     .hasMessage("No private key found for address: " + unknownAddress);
         }
-    }
-
-    private static UnsignedTransaction buildUnsignedTransaction(String intentId, String chain) {
-        return UnsignedTransaction.builder()
-                .intentId(intentId)
-                .chain(chain)
-                .fromAddress("from-address")
-                .toAddress("to-address")
-                .payload(SOME_PAYLOAD)
-                .feeEstimate(FeeEstimate.builder()
-                        .estimatedCost(BigDecimal.ZERO)
-                        .denomination("ETH")
-                        .urgency(FeeUrgency.MEDIUM)
-                        .build())
-                .build();
     }
 }

--- a/stablebridge-tx-recovery/src/testFixtures/java/com/stablebridge/txrecovery/testutil/fixtures/SignerFixtures.java
+++ b/stablebridge-tx-recovery/src/testFixtures/java/com/stablebridge/txrecovery/testutil/fixtures/SignerFixtures.java
@@ -1,0 +1,34 @@
+package com.stablebridge.txrecovery.testutil.fixtures;
+
+import java.math.BigDecimal;
+
+import com.stablebridge.txrecovery.domain.recovery.model.FeeEstimate;
+import com.stablebridge.txrecovery.domain.recovery.model.FeeUrgency;
+import com.stablebridge.txrecovery.domain.transaction.model.UnsignedTransaction;
+
+public final class SignerFixtures {
+
+    private SignerFixtures() {}
+
+    public static final String SOME_INTENT_ID = "intent-123";
+    public static final String SOME_EVM_CHAIN = "ethereum";
+    public static final String SOME_SOLANA_CHAIN = "solana-mainnet";
+    public static final String SOME_EVM_ADDRESS = "0xTestEvmAddress";
+    public static final String SOME_SOLANA_ADDRESS = "solana-test-address";
+    public static final byte[] SOME_PAYLOAD = {0x01, 0x02, 0x03, 0x04};
+
+    public static UnsignedTransaction someUnsignedTransaction(String intentId, String chain) {
+        return UnsignedTransaction.builder()
+                .intentId(intentId)
+                .chain(chain)
+                .fromAddress("from-address")
+                .toAddress("to-address")
+                .payload(SOME_PAYLOAD)
+                .feeEstimate(FeeEstimate.builder()
+                        .estimatedCost(BigDecimal.ZERO)
+                        .denomination("ETH")
+                        .urgency(FeeUrgency.MEDIUM)
+                        .build())
+                .build();
+    }
+}


### PR DESCRIPTION
## STR Issue
Closes #25

## Changes
- Add `LocalKeystoreSigner` implementing `TransactionSigner` port for development/testing
- ECDSA secp256k1 signing for EVM chains with Keccak-256 hash computation and low-s normalization
- EdDSA Ed25519 signing for Solana chains with 64-byte signature prepended to payload
- Chain detection via chain name (`solana` → Ed25519, else → secp256k1)
- In-memory key map (`Map<String, byte[]>` of address→privateKey) — keystore file loading deferred to STR-40
- Add `LocalSignerProperties` record for future `@ConfigurationProperties` binding
- Add `LocalKeystoreSignerTest` with programmatic key generation and cryptographic verification (5 tests)

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied