### PR TITLE
STR-40: add StrProperties @ConfigurationProperties with nested records

### DIFF
--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/config/StrProperties.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/config/StrProperties.java
@@ -27,7 +27,7 @@ public record StrProperties(
         @Valid EscalationProperties escalation,
         @Valid SubmissionProperties submission,
         @Valid TemporalConfigProperties temporal,
-        @Valid RedisConfigProperties redis,
+        @NotNull @Valid RedisConfigProperties redis,
         @NotEmpty Map<String, @Valid ChainProperties> chains) {
 
     public StrProperties {
@@ -36,6 +36,7 @@ public record StrProperties(
         escalation = Objects.requireNonNullElse(escalation, EscalationProperties.builder().build());
         submission = Objects.requireNonNullElse(submission, new SubmissionProperties(null, null));
         temporal = Objects.requireNonNullElse(temporal, TemporalConfigProperties.builder().build());
+        redis = Objects.requireNonNullElse(redis, new RedisConfigProperties(null, 0));
         chains = Objects.requireNonNullElse(chains, Map.of());
     }
 
@@ -90,8 +91,8 @@ public record StrProperties(
 
     @Builder(toBuilder = true)
     public record SubmissionProperties(
-            BigDecimal sequentialThresholdUsd,
-            Integer maxPipelineDepth) {
+            @NotNull @DecimalMin("0") BigDecimal sequentialThresholdUsd,
+            @NotNull @Min(1) Integer maxPipelineDepth) {
 
         public SubmissionProperties {
             sequentialThresholdUsd = Objects.requireNonNullElse(
@@ -188,51 +189,86 @@ public record StrProperties(
             @NotBlank String target,
             @NotBlank String namespace,
             @NotBlank String taskQueue,
-            @NotNull @Valid WorkflowProperties workflow,
-            @NotNull @Valid ActivityProperties activity) {
+            @NotNull Duration workflowExecutionTimeout,
+            @NotNull Duration workflowRunTimeout,
+            List<String> nonRetryableExceptions,
+            @NotNull @Valid ActivityOptionsProperties activityOptions) {
 
         public TemporalConfigProperties {
             target = Objects.requireNonNullElse(target, "localhost:7233");
             namespace = Objects.requireNonNullElse(namespace, "stablebridge-tx-recovery");
             taskQueue = Objects.requireNonNullElse(taskQueue, "str-transaction-lifecycle");
-            workflow = Objects.requireNonNullElse(
-                    workflow, WorkflowProperties.builder().build());
-            activity = Objects.requireNonNullElse(
-                    activity, ActivityProperties.builder().build());
+            workflowExecutionTimeout = Objects.requireNonNullElse(
+                    workflowExecutionTimeout, Duration.ofHours(24));
+            workflowRunTimeout = Objects.requireNonNullElse(
+                    workflowRunTimeout, Duration.ofHours(2));
+            nonRetryableExceptions = Objects.requireNonNullElse(nonRetryableExceptions, List.of(
+                    "com.stablebridge.txrecovery.domain.exception.NonRetryableException",
+                    "com.stablebridge.txrecovery.domain.exception.NonceTooLowException"));
+            activityOptions = Objects.requireNonNullElse(
+                    activityOptions, ActivityOptionsProperties.builder().build());
         }
 
         @Builder(toBuilder = true)
-        public record WorkflowProperties(
-                @NotNull Duration executionTimeout,
-                @NotNull Duration runTimeout) {
+        public record ActivityOptionsProperties(
+                @NotNull @Valid ActivityConfig defaultOptions,
+                @NotNull @Valid ActivityConfig signing,
+                @NotNull @Valid ActivityConfig confirmation,
+                @NotNull @Valid ActivityConfig recoveryExecution) {
 
-            public WorkflowProperties {
-                executionTimeout = Objects.requireNonNullElse(
-                        executionTimeout, Duration.ofHours(24));
-                runTimeout = Objects.requireNonNullElse(
-                        runTimeout, Duration.ofHours(2));
+            public ActivityOptionsProperties {
+                defaultOptions = Objects.requireNonNullElse(defaultOptions, ActivityConfig.builder()
+                        .startToCloseTimeout(Duration.ofSeconds(30))
+                        .maxAttempts(3)
+                        .initialInterval(Duration.ofSeconds(1))
+                        .backoffCoefficient(2.0)
+                        .build());
+                signing = Objects.requireNonNullElse(signing, ActivityConfig.builder()
+                        .startToCloseTimeout(Duration.ofSeconds(10))
+                        .maxAttempts(2)
+                        .initialInterval(Duration.ofSeconds(1))
+                        .backoffCoefficient(2.0)
+                        .build());
+                confirmation = Objects.requireNonNullElse(confirmation, ActivityConfig.builder()
+                        .startToCloseTimeout(Duration.ofMinutes(5))
+                        .maxAttempts(1)
+                        .initialInterval(Duration.ofSeconds(1))
+                        .backoffCoefficient(2.0)
+                        .build());
+                recoveryExecution = Objects.requireNonNullElse(recoveryExecution, ActivityConfig.builder()
+                        .startToCloseTimeout(Duration.ofSeconds(60))
+                        .maxAttempts(3)
+                        .initialInterval(Duration.ofSeconds(1))
+                        .backoffCoefficient(2.0)
+                        .build());
             }
         }
 
         @Builder(toBuilder = true)
-        public record ActivityProperties(
+        public record ActivityConfig(
                 @NotNull Duration startToCloseTimeout,
-                @Min(1) int retryMaxAttempts) {
+                @NotNull @Min(1) Integer maxAttempts,
+                @NotNull Duration initialInterval,
+                @NotNull Double backoffCoefficient) {
 
-            public ActivityProperties {
+            public ActivityConfig {
                 startToCloseTimeout = Objects.requireNonNullElse(
                         startToCloseTimeout, Duration.ofSeconds(30));
-                retryMaxAttempts = retryMaxAttempts <= 0 ? 3 : retryMaxAttempts;
+                maxAttempts = Objects.requireNonNullElse(maxAttempts, 3);
+                initialInterval = Objects.requireNonNullElse(
+                        initialInterval, Duration.ofSeconds(1));
+                backoffCoefficient = Objects.requireNonNullElse(backoffCoefficient, 2.0);
             }
         }
     }
 
     @Builder(toBuilder = true)
     public record RedisConfigProperties(
-            String host,
+            @NotBlank String host,
             int port) {
 
         public RedisConfigProperties {
+            host = Objects.requireNonNullElse(host, "localhost");
             if (port <= 0) {
                 port = 6379;
             }

--- a/stablebridge-tx-recovery/src/main/resources/application.yml
+++ b/stablebridge-tx-recovery/src/main/resources/application.yml
@@ -210,7 +210,7 @@ str:
       chain-id: 0
       finality-blocks: 31
       stuck-threshold-blocks: 150
-      poll-interval: PT400MS
+      poll-interval: 400ms
       token-mints:
         - "EPjFWdd5AufqSSqeM2qN1xzybapC8G4wEGGkZwyTDt1v"
       rpc:

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/config/StrPropertiesTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/config/StrPropertiesTest.java
@@ -27,8 +27,7 @@ import com.stablebridge.txrecovery.application.config.StrProperties.SignerProper
 import com.stablebridge.txrecovery.application.config.StrProperties.SignerProperties.CallbackProperties.TlsProperties;
 import com.stablebridge.txrecovery.application.config.StrProperties.SubmissionProperties;
 import com.stablebridge.txrecovery.application.config.StrProperties.TemporalConfigProperties;
-import com.stablebridge.txrecovery.application.config.StrProperties.TemporalConfigProperties.ActivityProperties;
-import com.stablebridge.txrecovery.application.config.StrProperties.TemporalConfigProperties.WorkflowProperties;
+import com.stablebridge.txrecovery.application.config.StrProperties.TemporalConfigProperties.ActivityOptionsProperties;
 
 class StrPropertiesTest {
 
@@ -45,7 +44,7 @@ class StrPropertiesTest {
                     .escalation(EscalationProperties.builder().build())
                     .submission(new SubmissionProperties(null, null))
                     .temporal(TemporalConfigProperties.builder().build())
-                    .redis(null)
+                    .redis(new RedisConfigProperties(null, 0))
                     .chains(Map.of())
                     .build();
 
@@ -252,22 +251,29 @@ class StrPropertiesTest {
             assertThat(temporal.target()).isEqualTo("localhost:7233");
             assertThat(temporal.namespace()).isEqualTo("stablebridge-tx-recovery");
             assertThat(temporal.taskQueue()).isEqualTo("str-transaction-lifecycle");
+            assertThat(temporal.workflowExecutionTimeout()).isEqualTo(Duration.ofHours(24));
+            assertThat(temporal.workflowRunTimeout()).isEqualTo(Duration.ofHours(2));
+            assertThat(temporal.nonRetryableExceptions()).containsExactly(
+                    "com.stablebridge.txrecovery.domain.exception.NonRetryableException",
+                    "com.stablebridge.txrecovery.domain.exception.NonceTooLowException");
         }
 
         @Test
-        void shouldApplyDefaultWorkflowValues() {
-            var workflow = WorkflowProperties.builder().build();
+        void shouldApplyDefaultActivityOptionsValues() {
+            var activityOptions = ActivityOptionsProperties.builder().build();
 
-            assertThat(workflow.executionTimeout()).isEqualTo(Duration.ofHours(24));
-            assertThat(workflow.runTimeout()).isEqualTo(Duration.ofHours(2));
-        }
-
-        @Test
-        void shouldApplyDefaultActivityValues() {
-            var activity = ActivityProperties.builder().build();
-
-            assertThat(activity.startToCloseTimeout()).isEqualTo(Duration.ofSeconds(30));
-            assertThat(activity.retryMaxAttempts()).isEqualTo(3);
+            assertThat(activityOptions.defaultOptions().startToCloseTimeout())
+                    .isEqualTo(Duration.ofSeconds(30));
+            assertThat(activityOptions.defaultOptions().maxAttempts()).isEqualTo(3);
+            assertThat(activityOptions.signing().startToCloseTimeout())
+                    .isEqualTo(Duration.ofSeconds(10));
+            assertThat(activityOptions.signing().maxAttempts()).isEqualTo(2);
+            assertThat(activityOptions.confirmation().startToCloseTimeout())
+                    .isEqualTo(Duration.ofMinutes(5));
+            assertThat(activityOptions.confirmation().maxAttempts()).isEqualTo(1);
+            assertThat(activityOptions.recoveryExecution().startToCloseTimeout())
+                    .isEqualTo(Duration.ofSeconds(60));
+            assertThat(activityOptions.recoveryExecution().maxAttempts()).isEqualTo(3);
         }
     }
 
@@ -275,14 +281,15 @@ class StrPropertiesTest {
     class RedisConfigPropertiesTests {
 
         @Test
-        void shouldApplyDefaultPort() {
-            var redis = new RedisConfigProperties("localhost", 0);
+        void shouldApplyDefaultHostAndPort() {
+            var redis = new RedisConfigProperties(null, 0);
 
+            assertThat(redis.host()).isEqualTo("localhost");
             assertThat(redis.port()).isEqualTo(6379);
         }
 
         @Test
-        void shouldPreserveCustomPort() {
+        void shouldPreserveCustomValues() {
             var redis = new RedisConfigProperties("redis.prod", 6380);
 
             assertThat(redis.host()).isEqualTo("redis.prod");
@@ -324,10 +331,25 @@ class StrPropertiesTest {
                             "str.temporal.target=temporal-test:7233",
                             "str.temporal.namespace=test-ns",
                             "str.temporal.task-queue=test-queue",
-                            "str.temporal.workflow.execution-timeout=PT48H",
-                            "str.temporal.workflow.run-timeout=PT4H",
-                            "str.temporal.activity.start-to-close-timeout=PT60S",
-                            "str.temporal.activity.retry-max-attempts=5",
+                            "str.temporal.workflow-execution-timeout=PT48H",
+                            "str.temporal.workflow-run-timeout=PT4H",
+                            "str.temporal.non-retryable-exceptions[0]=com.example.TestException",
+                            "str.temporal.activity-options.default-options.start-to-close-timeout=PT60S",
+                            "str.temporal.activity-options.default-options.max-attempts=5",
+                            "str.temporal.activity-options.default-options.initial-interval=PT2S",
+                            "str.temporal.activity-options.default-options.backoff-coefficient=3.0",
+                            "str.temporal.activity-options.signing.start-to-close-timeout=PT15S",
+                            "str.temporal.activity-options.signing.max-attempts=3",
+                            "str.temporal.activity-options.signing.initial-interval=PT1S",
+                            "str.temporal.activity-options.signing.backoff-coefficient=2.0",
+                            "str.temporal.activity-options.confirmation.start-to-close-timeout=PT300S",
+                            "str.temporal.activity-options.confirmation.max-attempts=1",
+                            "str.temporal.activity-options.confirmation.initial-interval=PT1S",
+                            "str.temporal.activity-options.confirmation.backoff-coefficient=2.0",
+                            "str.temporal.activity-options.recovery-execution.start-to-close-timeout=PT60S",
+                            "str.temporal.activity-options.recovery-execution.max-attempts=3",
+                            "str.temporal.activity-options.recovery-execution.initial-interval=PT1S",
+                            "str.temporal.activity-options.recovery-execution.backoff-coefficient=2.0",
                             "str.redis.host=redis-test",
                             "str.redis.port=6380",
                             "str.chains.ethereum_mainnet.enabled=true",
@@ -368,9 +390,16 @@ class StrPropertiesTest {
 
                 assertThat(props.temporal().target()).isEqualTo("temporal-test:7233");
                 assertThat(props.temporal().namespace()).isEqualTo("test-ns");
-                assertThat(props.temporal().workflow().executionTimeout())
+                assertThat(props.temporal().workflowExecutionTimeout())
                         .isEqualTo(Duration.ofHours(48));
-                assertThat(props.temporal().activity().retryMaxAttempts()).isEqualTo(5);
+                assertThat(props.temporal().workflowRunTimeout())
+                        .isEqualTo(Duration.ofHours(4));
+                assertThat(props.temporal().nonRetryableExceptions())
+                        .containsExactly("com.example.TestException");
+                assertThat(props.temporal().activityOptions().defaultOptions().maxAttempts())
+                        .isEqualTo(5);
+                assertThat(props.temporal().activityOptions().signing().startToCloseTimeout())
+                        .isEqualTo(Duration.ofSeconds(15));
 
                 assertThat(props.redis().host()).isEqualTo("redis-test");
                 assertThat(props.redis().port()).isEqualTo(6380);


### PR DESCRIPTION
## Summary
- Add unified `StrProperties` record with `@ConfigurationProperties(prefix = "str")` binding all configuration to type-safe nested records
- Add per-chain configuration map (`str.chains.*`) for ethereum_mainnet, base_mainnet, polygon_mainnet, solana_mainnet with RPC, circuit breaker, and token config
- Add `SubmissionProperties`, `RedisConfigProperties`, and `TemporalConfigProperties` nested records with sensible defaults
- Add unit tests verifying defaults, validation, and Spring Boot YAML binding via `ApplicationContextRunner`

Closes #40

## Test plan
- [x] Unit tests for all nested record defaults
- [x] Gas budget min/max validation test
- [x] ApplicationContextRunner YAML binding test
- [x] Full build passes with spotless + all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added comprehensive configuration support for multiple blockchain networks (Ethereum, Base, Polygon, and Solana) with customizable RPC endpoints, polling intervals, and finality settings
  * Added Redis connectivity configuration options
  * Added transaction submission control parameters including sequential thresholds and pipeline depth limits
  * Added circuit breaker and rate limiting configuration for improved RPC reliability

<!-- end of auto-generated comment: release notes by coderabbit.ai -->