### PR TITLE
STR-37: extract operator identity from API key for approval audit trail

### DIFF
--- a/stablebridge-tx-recovery/src/integration-test/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalControllerIntegrationTest.java
+++ b/stablebridge-tx-recovery/src/integration-test/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalControllerIntegrationTest.java
@@ -3,6 +3,7 @@ package com.stablebridge.txrecovery.application.controller.approval;
 import static com.stablebridge.txrecovery.testutil.fixtures.ApprovalControllerFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -10,11 +11,15 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.stablebridge.txrecovery.api.model.ApproveTransactionResponse;
 import com.stablebridge.txrecovery.api.model.CancelTransactionResponse;
+import com.stablebridge.txrecovery.domain.recovery.model.CancelRequest;
+import com.stablebridge.txrecovery.domain.recovery.model.HumanApproval;
 import com.stablebridge.txrecovery.domain.transaction.port.TransactionProjectionStore;
 import com.stablebridge.txrecovery.domain.transaction.port.TransactionWorkflowSignaler;
 import com.stablebridge.txrecovery.testutil.ControllerIntegrationTestBase;
@@ -25,6 +30,9 @@ class ApprovalControllerIntegrationTest extends ControllerIntegrationTestBase {
 
     private static final String APPROVE_PATH = "/api/v1/transactions/%s/approve";
     private static final String CANCEL_PATH = "/api/v1/transactions/%s/cancel";
+
+    @Value("${str.api.operators.compliance-officer}")
+    private String complianceOfficerKey;
 
     @MockitoBean
     private TransactionProjectionStore transactionProjectionStore;
@@ -58,6 +66,45 @@ class ApprovalControllerIntegrationTest extends ControllerIntegrationTestBase {
                     .ignoringFields("approvedAt")
                     .isEqualTo(expected);
             assertThat(response.approvedAt()).isNotNull();
+        }
+
+        @Test
+        void shouldPropagateOpsLeadIdentityToApproval() throws Exception {
+            given(transactionProjectionStore.findById(SOME_APPROVAL_TRANSACTION_ID))
+                    .willReturn(Optional.of(AWAITING_HUMAN_PROJECTION));
+
+            mockMvc.perform(authenticatedJson(
+                            post(APPROVE_PATH.formatted(SOME_APPROVAL_TRANSACTION_ID)),
+                            objectMapper.writeValueAsString(SOME_APPROVE_REQUEST)))
+                    .andExpect(status().isOk());
+
+            var txIdCaptor = ArgumentCaptor.forClass(String.class);
+            var approvalCaptor = ArgumentCaptor.forClass(HumanApproval.class);
+            then(transactionWorkflowSignaler)
+                    .should()
+                    .signalApproveRecovery(txIdCaptor.capture(), approvalCaptor.capture());
+
+            assertThat(approvalCaptor.getValue().approvedBy()).isEqualTo("ops-lead");
+        }
+
+        @Test
+        void shouldPropagateComplianceOfficerIdentityToApproval() throws Exception {
+            given(transactionProjectionStore.findById(SOME_APPROVAL_TRANSACTION_ID))
+                    .willReturn(Optional.of(AWAITING_HUMAN_PROJECTION));
+
+            mockMvc.perform(authenticatedAsJson(
+                            post(APPROVE_PATH.formatted(SOME_APPROVAL_TRANSACTION_ID)),
+                            complianceOfficerKey,
+                            objectMapper.writeValueAsString(SOME_APPROVE_REQUEST)))
+                    .andExpect(status().isOk());
+
+            var txIdCaptor = ArgumentCaptor.forClass(String.class);
+            var approvalCaptor = ArgumentCaptor.forClass(HumanApproval.class);
+            then(transactionWorkflowSignaler)
+                    .should()
+                    .signalApproveRecovery(txIdCaptor.capture(), approvalCaptor.capture());
+
+            assertThat(approvalCaptor.getValue().approvedBy()).isEqualTo("compliance-officer");
         }
 
         @Test
@@ -140,6 +187,26 @@ class ApprovalControllerIntegrationTest extends ControllerIntegrationTestBase {
             assertThat(response)
                     .usingRecursiveComparison()
                     .isEqualTo(expected);
+        }
+
+        @Test
+        void shouldPropagateComplianceOfficerIdentityToCancel() throws Exception {
+            given(transactionProjectionStore.findById(SOME_APPROVAL_TRANSACTION_ID))
+                    .willReturn(Optional.of(PENDING_PROJECTION));
+
+            mockMvc.perform(authenticatedAsJson(
+                            post(CANCEL_PATH.formatted(SOME_APPROVAL_TRANSACTION_ID)),
+                            complianceOfficerKey,
+                            objectMapper.writeValueAsString(SOME_CANCEL_REQUEST)))
+                    .andExpect(status().isOk());
+
+            var txIdCaptor = ArgumentCaptor.forClass(String.class);
+            var cancelCaptor = ArgumentCaptor.forClass(CancelRequest.class);
+            then(transactionWorkflowSignaler)
+                    .should()
+                    .signalCancelTransaction(txIdCaptor.capture(), cancelCaptor.capture());
+
+            assertThat(cancelCaptor.getValue().requestedBy()).isEqualTo("compliance-officer");
         }
 
         @Test

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalController.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalController.java
@@ -1,5 +1,8 @@
 package com.stablebridge.txrecovery.application.controller.approval;
 
+import java.util.Optional;
+
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 
 import org.springframework.http.ResponseEntity;
@@ -27,7 +30,8 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 public class ApprovalController {
 
-    private static final String SYSTEM_USER = "system";
+    static final String OPERATOR_IDENTITY_ATTR = "str.operator.identity";
+    private static final String DEFAULT_OPERATOR = "system";
 
     private final TransactionApprovalService transactionApprovalService;
     private final ApprovalControllerMapper approvalControllerMapper;
@@ -35,10 +39,12 @@ public class ApprovalController {
     @PostMapping("/approve")
     public ResponseEntity<ApproveTransactionResponse> approveTransaction(
             @PathVariable String transactionId,
-            @Valid @RequestBody ApproveTransactionRequest request) {
+            @Valid @RequestBody ApproveTransactionRequest request,
+            HttpServletRequest httpRequest) {
+        var operatorIdentity = extractOperatorIdentity(httpRequest);
         var action = approvalControllerMapper.toDomain(request.action());
         var result = transactionApprovalService.approveTransaction(
-                transactionId, action, request.reason(), SYSTEM_USER);
+                transactionId, action, request.reason(), operatorIdentity);
         var response = approvalControllerMapper.toApproveResponse(result);
         return ResponseEntity.ok(response);
     }
@@ -46,10 +52,17 @@ public class ApprovalController {
     @PostMapping("/cancel")
     public ResponseEntity<CancelTransactionResponse> cancelTransaction(
             @PathVariable String transactionId,
-            @Valid @RequestBody CancelTransactionRequest request) {
+            @Valid @RequestBody CancelTransactionRequest request,
+            HttpServletRequest httpRequest) {
+        var operatorIdentity = extractOperatorIdentity(httpRequest);
         var result = transactionApprovalService.cancelTransaction(
-                transactionId, request.reason(), SYSTEM_USER);
+                transactionId, request.reason(), operatorIdentity);
         var response = approvalControllerMapper.toCancelResponse(result);
         return ResponseEntity.ok(response);
+    }
+
+    private String extractOperatorIdentity(HttpServletRequest request) {
+        return Optional.ofNullable((String) request.getAttribute(OPERATOR_IDENTITY_ATTR))
+                .orElse(DEFAULT_OPERATOR);
     }
 }

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilter.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilter.java
@@ -3,6 +3,7 @@ package com.stablebridge.txrecovery.application.security;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
+import java.util.Map;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
@@ -20,12 +21,13 @@ import lombok.extern.slf4j.Slf4j;
 public class ApiKeyAuthFilter extends OncePerRequestFilter {
 
     static final String API_KEY_HEADER = "X-API-Key";
+    static final String OPERATOR_IDENTITY_ATTRIBUTE = "str.operator.identity";
     static final String ERROR_CODE = "STR-4010";
     static final String ERROR_MESSAGE = "Unauthorized";
     static final String ERROR_RESPONSE_BODY =
             "{\"error\": \"" + ERROR_CODE + "\", \"message\": \"" + ERROR_MESSAGE + "\"}";
 
-    private final String configuredApiKey;
+    private final Map<String, String> keyToOperator;
 
     @Override
     protected void doFilterInternal(
@@ -34,22 +36,38 @@ public class ApiKeyAuthFilter extends OncePerRequestFilter {
 
         var providedKey = request.getHeader(API_KEY_HEADER);
 
-        if (configuredApiKey == null || configuredApiKey.isBlank()) {
+        if (keyToOperator.isEmpty()) {
             log.warn("API key not configured — rejecting request to {}", request.getRequestURI());
             sendUnauthorized(response);
             return;
         }
 
-        if (providedKey == null
-                || !MessageDigest.isEqual(
-                        configuredApiKey.getBytes(StandardCharsets.UTF_8),
-                        providedKey.getBytes(StandardCharsets.UTF_8))) {
-            log.warn("Invalid or missing API key for request to {}", request.getRequestURI());
+        if (providedKey == null) {
+            log.warn("Missing API key for request to {}", request.getRequestURI());
             sendUnauthorized(response);
             return;
         }
 
+        var operatorName = findOperator(providedKey);
+        if (operatorName == null) {
+            log.warn("Invalid API key for request to {}", request.getRequestURI());
+            sendUnauthorized(response);
+            return;
+        }
+
+        request.setAttribute(OPERATOR_IDENTITY_ATTRIBUTE, operatorName);
         filterChain.doFilter(request, response);
+    }
+
+    private String findOperator(String providedKey) {
+        var providedBytes = providedKey.getBytes(StandardCharsets.UTF_8);
+        for (var entry : keyToOperator.entrySet()) {
+            var configuredBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
+            if (MessageDigest.isEqual(configuredBytes, providedBytes)) {
+                return entry.getValue();
+            }
+        }
+        return null;
     }
 
     private void sendUnauthorized(HttpServletResponse response) throws IOException {

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterConfig.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterConfig.java
@@ -1,5 +1,8 @@
 package com.stablebridge.txrecovery.application.security;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
@@ -16,9 +19,21 @@ public class ApiKeyAuthFilterConfig {
 
     @Bean
     FilterRegistrationBean<ApiKeyAuthFilter> apiKeyAuthFilterRegistration() {
-        var registration = new FilterRegistrationBean<>(new ApiKeyAuthFilter(apiKeyProperties.key()));
+        var registration = new FilterRegistrationBean<>(new ApiKeyAuthFilter(buildKeyToOperatorMap()));
         registration.addUrlPatterns("/api/v1/*");
         registration.setOrder(1);
         return registration;
+    }
+
+    private Map<String, String> buildKeyToOperatorMap() {
+        if (!apiKeyProperties.operators().isEmpty()) {
+            var keyToOperator = new HashMap<String, String>();
+            apiKeyProperties.operators().forEach((operator, key) -> keyToOperator.put(key, operator));
+            return Map.copyOf(keyToOperator);
+        }
+        if (apiKeyProperties.key() != null && !apiKeyProperties.key().isBlank()) {
+            return Map.of(apiKeyProperties.key(), "system");
+        }
+        return Map.of();
     }
 }

--- a/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyProperties.java
+++ b/stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/security/ApiKeyProperties.java
@@ -1,13 +1,15 @@
 package com.stablebridge.txrecovery.application.security;
 
+import java.util.Map;
 import java.util.Objects;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties(prefix = "str.api")
-public record ApiKeyProperties(String key) {
+public record ApiKeyProperties(String key, Map<String, String> operators) {
 
     public ApiKeyProperties {
         key = Objects.requireNonNullElse(key, "");
+        operators = Objects.requireNonNullElse(operators, Map.of());
     }
 }

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalControllerTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalControllerTest.java
@@ -1,5 +1,6 @@
 package com.stablebridge.txrecovery.application.controller.approval;
 
+import static com.stablebridge.txrecovery.application.controller.approval.ApprovalController.OPERATOR_IDENTITY_ATTR;
 import static com.stablebridge.txrecovery.testutil.fixtures.ApprovalControllerFixtures.*;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
@@ -33,6 +34,8 @@ import com.stablebridge.txrecovery.domain.transaction.TransactionApprovalService
 @ExtendWith(MockitoExtension.class)
 class ApprovalControllerTest {
 
+    private static final String SOME_OPERATOR = "test-operator";
+
     @Mock
     private TransactionApprovalService transactionApprovalService;
 
@@ -63,6 +66,31 @@ class ApprovalControllerTest {
             given(approvalControllerMapper.toDomain(ApprovalActionDto.RETRY))
                     .willReturn(ApprovalAction.RETRY);
             given(transactionApprovalService.approveTransaction(
+                    SOME_APPROVAL_TRANSACTION_ID, ApprovalAction.RETRY, SOME_APPROVAL_REASON, SOME_OPERATOR))
+                    .willReturn(SOME_APPROVAL_RESULT);
+            given(approvalControllerMapper.toApproveResponse(SOME_APPROVAL_RESULT))
+                    .willReturn(SOME_APPROVE_RESPONSE);
+
+            var result = mockMvc.perform(post("/api/v1/transactions/{transactionId}/approve",
+                            SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(SOME_APPROVE_REQUEST)))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            var response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(), ApproveTransactionResponse.class);
+            assertThat(response)
+                    .usingRecursiveComparison()
+                    .isEqualTo(SOME_APPROVE_RESPONSE);
+        }
+
+        @Test
+        void shouldFallBackToSystemWhenOperatorIdentityNotSet() throws Exception {
+            given(approvalControllerMapper.toDomain(ApprovalActionDto.RETRY))
+                    .willReturn(ApprovalAction.RETRY);
+            given(transactionApprovalService.approveTransaction(
                     SOME_APPROVAL_TRANSACTION_ID, ApprovalAction.RETRY, SOME_APPROVAL_REASON, "system"))
                     .willReturn(SOME_APPROVAL_RESULT);
             given(approvalControllerMapper.toApproveResponse(SOME_APPROVAL_RESULT))
@@ -87,11 +115,12 @@ class ApprovalControllerTest {
             given(approvalControllerMapper.toDomain(ApprovalActionDto.RETRY))
                     .willReturn(ApprovalAction.RETRY);
             given(transactionApprovalService.approveTransaction(
-                    SOME_APPROVAL_TRANSACTION_ID, ApprovalAction.RETRY, SOME_APPROVAL_REASON, "system"))
+                    SOME_APPROVAL_TRANSACTION_ID, ApprovalAction.RETRY, SOME_APPROVAL_REASON, SOME_OPERATOR))
                     .willThrow(new InvalidTransactionStateException(SOME_APPROVAL_TRANSACTION_ID, "PENDING"));
 
             var result = mockMvc.perform(post("/api/v1/transactions/{transactionId}/approve",
                             SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(SOME_APPROVE_REQUEST)))
                     .andExpect(status().isConflict())
@@ -108,10 +137,11 @@ class ApprovalControllerTest {
             given(approvalControllerMapper.toDomain(ApprovalActionDto.RETRY))
                     .willReturn(ApprovalAction.RETRY);
             given(transactionApprovalService.approveTransaction(
-                    "non-existent-tx", ApprovalAction.RETRY, SOME_APPROVAL_REASON, "system"))
+                    "non-existent-tx", ApprovalAction.RETRY, SOME_APPROVAL_REASON, SOME_OPERATOR))
                     .willThrow(new TransactionNotFoundException("non-existent-tx"));
 
             mockMvc.perform(post("/api/v1/transactions/{transactionId}/approve", "non-existent-tx")
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(SOME_APPROVE_REQUEST)))
                     .andExpect(status().isNotFound());
@@ -123,6 +153,7 @@ class ApprovalControllerTest {
 
             mockMvc.perform(post("/api/v1/transactions/{transactionId}/approve",
                             SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(invalidRequest)))
                     .andExpect(status().isBadRequest());
@@ -134,6 +165,7 @@ class ApprovalControllerTest {
 
             mockMvc.perform(post("/api/v1/transactions/{transactionId}/approve",
                             SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(invalidRequest)))
                     .andExpect(status().isBadRequest());
@@ -145,6 +177,29 @@ class ApprovalControllerTest {
 
         @Test
         void shouldCancelTransactionAndReturn200() throws Exception {
+            given(transactionApprovalService.cancelTransaction(
+                    SOME_APPROVAL_TRANSACTION_ID, SOME_CANCEL_REASON, SOME_OPERATOR))
+                    .willReturn(SOME_CANCELLATION_RESULT);
+            given(approvalControllerMapper.toCancelResponse(SOME_CANCELLATION_RESULT))
+                    .willReturn(SOME_CANCEL_RESPONSE);
+
+            var result = mockMvc.perform(post("/api/v1/transactions/{transactionId}/cancel",
+                            SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(SOME_CANCEL_REQUEST)))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            var response = objectMapper.readValue(
+                    result.getResponse().getContentAsString(), CancelTransactionResponse.class);
+            assertThat(response)
+                    .usingRecursiveComparison()
+                    .isEqualTo(SOME_CANCEL_RESPONSE);
+        }
+
+        @Test
+        void shouldFallBackToSystemWhenOperatorIdentityNotSet() throws Exception {
             given(transactionApprovalService.cancelTransaction(
                     SOME_APPROVAL_TRANSACTION_ID, SOME_CANCEL_REASON, "system"))
                     .willReturn(SOME_CANCELLATION_RESULT);
@@ -168,11 +223,12 @@ class ApprovalControllerTest {
         @Test
         void shouldReturn409WhenTransactionIsInTerminalStatus() throws Exception {
             given(transactionApprovalService.cancelTransaction(
-                    SOME_APPROVAL_TRANSACTION_ID, SOME_CANCEL_REASON, "system"))
+                    SOME_APPROVAL_TRANSACTION_ID, SOME_CANCEL_REASON, SOME_OPERATOR))
                     .willThrow(new TerminalTransactionException(SOME_APPROVAL_TRANSACTION_ID, "FINALIZED"));
 
             mockMvc.perform(post("/api/v1/transactions/{transactionId}/cancel",
                             SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(SOME_CANCEL_REQUEST)))
                     .andExpect(status().isConflict());
@@ -181,10 +237,11 @@ class ApprovalControllerTest {
         @Test
         void shouldReturn404WhenTransactionNotFound() throws Exception {
             given(transactionApprovalService.cancelTransaction(
-                    "non-existent-tx", SOME_CANCEL_REASON, "system"))
+                    "non-existent-tx", SOME_CANCEL_REASON, SOME_OPERATOR))
                     .willThrow(new TransactionNotFoundException("non-existent-tx"));
 
             mockMvc.perform(post("/api/v1/transactions/{transactionId}/cancel", "non-existent-tx")
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(SOME_CANCEL_REQUEST)))
                     .andExpect(status().isNotFound());
@@ -196,6 +253,7 @@ class ApprovalControllerTest {
 
             mockMvc.perform(post("/api/v1/transactions/{transactionId}/cancel",
                             SOME_APPROVAL_TRANSACTION_ID)
+                            .requestAttr(OPERATOR_IDENTITY_ATTR, SOME_OPERATOR)
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(invalidRequest)))
                     .andExpect(status().isBadRequest());

--- a/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterTest.java
+++ b/stablebridge-tx-recovery/src/test/java/com/stablebridge/txrecovery/application/security/ApiKeyAuthFilterTest.java
@@ -1,9 +1,14 @@
 package com.stablebridge.txrecovery.application.security;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.util.Map;
+
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -16,16 +21,22 @@ import org.springframework.web.bind.annotation.RestController;
 
 class ApiKeyAuthFilterTest {
 
-    static final String VALID_API_KEY = "test-secret-key-12345";
+    static final String OPS_LEAD_KEY = "key-for-ops-lead";
+    static final String COMPLIANCE_KEY = "key-for-compliance";
     static final String API_ENDPOINT = "/api/v1/test";
     static final String ACTUATOR_ENDPOINT = "/actuator/health";
+
+    static final Map<String, String> OPERATOR_KEY_MAP = Map.of(
+            OPS_LEAD_KEY, "ops-lead",
+            COMPLIANCE_KEY, "compliance-officer");
 
     @RestController
     static class TestController {
 
         @GetMapping("/api/v1/test")
-        ResponseEntity<String> apiEndpoint() {
-            return ResponseEntity.ok("{\"status\": \"ok\"}");
+        ResponseEntity<String> apiEndpoint(HttpServletRequest request) {
+            var operator = request.getAttribute(ApiKeyAuthFilter.OPERATOR_IDENTITY_ATTRIBUTE);
+            return ResponseEntity.ok("{\"operator\": \"" + operator + "\"}");
         }
 
         @GetMapping("/actuator/health")
@@ -34,28 +45,54 @@ class ApiKeyAuthFilterTest {
         }
     }
 
-    private MockMvc buildMockMvc(String apiKey) {
+    private MockMvc buildMockMvc(Map<String, String> keyToOperator) {
         return MockMvcBuilders.standaloneSetup(new TestController())
-                .addFilter(new ApiKeyAuthFilter(apiKey), "/api/v1/*")
+                .addFilter(new ApiKeyAuthFilter(keyToOperator), "/api/v1/*")
                 .build();
     }
 
     @Nested
-    class WhenApiKeyConfigured {
+    class WhenOperatorsConfigured {
 
-        private final MockMvc mockMvc = buildMockMvc(VALID_API_KEY);
+        private final MockMvc mockMvc = buildMockMvc(OPERATOR_KEY_MAP);
 
         @Test
         void shouldAllowRequestWithValidApiKey() throws Exception {
-            // when / then
-            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, VALID_API_KEY))
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, OPS_LEAD_KEY))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        void shouldSetOperatorIdentityForOpsLead() throws Exception {
+            var result = mockMvc.perform(
+                            get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, OPS_LEAD_KEY))
                     .andExpect(status().isOk())
-                    .andExpect(content().string("{\"status\": \"ok\"}"));
+                    .andReturn();
+
+            assertThat(result.getRequest().getAttribute(ApiKeyAuthFilter.OPERATOR_IDENTITY_ATTRIBUTE))
+                    .isEqualTo("ops-lead");
+        }
+
+        @Test
+        void shouldSetOperatorIdentityForComplianceOfficer() throws Exception {
+            var result = mockMvc.perform(
+                            get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, COMPLIANCE_KEY))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            assertThat(result.getRequest().getAttribute(ApiKeyAuthFilter.OPERATOR_IDENTITY_ATTRIBUTE))
+                    .isEqualTo("compliance-officer");
+        }
+
+        @Test
+        void shouldReturnOperatorInResponseBody() throws Exception {
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, OPS_LEAD_KEY))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("{\"operator\": \"ops-lead\"}"));
         }
 
         @Test
         void shouldRejectRequestWithInvalidApiKey() throws Exception {
-            // when / then
             mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "wrong-key"))
                     .andExpect(status().isUnauthorized())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -65,7 +102,6 @@ class ApiKeyAuthFilterTest {
 
         @Test
         void shouldRejectRequestWithMissingApiKey() throws Exception {
-            // when / then
             mockMvc.perform(get(API_ENDPOINT))
                     .andExpect(status().isUnauthorized())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
@@ -75,7 +111,6 @@ class ApiKeyAuthFilterTest {
 
         @Test
         void shouldAllowActuatorWithoutApiKey() throws Exception {
-            // when / then
             mockMvc.perform(get(ACTUATOR_ENDPOINT))
                     .andExpect(status().isOk())
                     .andExpect(content().string("{\"status\": \"UP\"}"));
@@ -83,29 +118,36 @@ class ApiKeyAuthFilterTest {
     }
 
     @Nested
-    class WhenApiKeyNotConfigured {
+    class WhenSingleKeyFallback {
 
-        private final MockMvc mockMvc = buildMockMvc("");
+        private final MockMvc mockMvc = buildMockMvc(Map.of("legacy-key", "system"));
 
         @Test
-        void shouldRejectRequestWhenApiKeyNotConfigured() throws Exception {
-            // when / then
-            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "any-key"))
-                    .andExpect(status().isUnauthorized())
-                    .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-                    .andExpect(jsonPath("$.error").value(ApiKeyAuthFilter.ERROR_CODE))
-                    .andExpect(jsonPath("$.message").value(ApiKeyAuthFilter.ERROR_MESSAGE));
+        void shouldAllowRequestWithLegacyKey() throws Exception {
+            mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "legacy-key"))
+                    .andExpect(status().isOk())
+                    .andExpect(content().string("{\"operator\": \"system\"}"));
+        }
+
+        @Test
+        void shouldSetSystemOperatorIdentity() throws Exception {
+            var result = mockMvc.perform(
+                            get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "legacy-key"))
+                    .andExpect(status().isOk())
+                    .andReturn();
+
+            assertThat(result.getRequest().getAttribute(ApiKeyAuthFilter.OPERATOR_IDENTITY_ATTRIBUTE))
+                    .isEqualTo("system");
         }
     }
 
     @Nested
-    class WhenApiKeyNull {
+    class WhenNoKeysConfigured {
 
-        private final MockMvc mockMvc = buildMockMvc(null);
+        private final MockMvc mockMvc = buildMockMvc(Map.of());
 
         @Test
-        void shouldRejectRequestWhenApiKeyIsNull() throws Exception {
-            // when / then
+        void shouldRejectRequestWhenNoKeysConfigured() throws Exception {
             mockMvc.perform(get(API_ENDPOINT).header(ApiKeyAuthFilter.API_KEY_HEADER, "any-key"))
                     .andExpect(status().isUnauthorized())
                     .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))

--- a/stablebridge-tx-recovery/src/test/resources/application-test.yml
+++ b/stablebridge-tx-recovery/src/test/resources/application-test.yml
@@ -11,6 +11,9 @@ spring:
 str:
   api:
     key: test-api-key
+    operators:
+      ops-lead: key-for-ops-lead
+      compliance-officer: key-for-compliance
   signer:
     backend: local-keystore
     keystore-path: test-keystore.p12

--- a/stablebridge-tx-recovery/src/testFixtures/java/com/stablebridge/txrecovery/testutil/ControllerIntegrationTestBase.java
+++ b/stablebridge-tx-recovery/src/testFixtures/java/com/stablebridge/txrecovery/testutil/ControllerIntegrationTestBase.java
@@ -21,11 +21,23 @@ public abstract class ControllerIntegrationTestBase extends IntegrationTestBase 
     @Autowired
     protected MockMvc mockMvc;
 
-    @Value("${str.api.key}")
+    @Value("${str.api.operators.ops-lead}")
     protected String apiKey;
 
     protected MockHttpServletRequestBuilder authenticated(MockHttpServletRequestBuilder requestBuilder) {
         return requestBuilder.header(API_KEY_HEADER, apiKey);
+    }
+
+    protected MockHttpServletRequestBuilder authenticatedAs(MockHttpServletRequestBuilder requestBuilder,
+            String operatorApiKey) {
+        return requestBuilder.header(API_KEY_HEADER, operatorApiKey);
+    }
+
+    protected MockHttpServletRequestBuilder authenticatedAsJson(MockHttpServletRequestBuilder requestBuilder,
+            String operatorApiKey, String body) {
+        return authenticatedAs(requestBuilder, operatorApiKey)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body);
     }
 
     protected MockHttpServletRequestBuilder authenticatedJson(MockHttpServletRequestBuilder requestBuilder,


### PR DESCRIPTION
## STR Issue
Closes #102

## Changes
- **ApiKeyProperties**: add `Map<String, String> operators` field mapping operator names to API keys, with backward-compatible single `key` fallback
- **ApiKeyAuthFilter**: resolve operator identity from presented API key using constant-time comparison, store as `str.operator.identity` request attribute
- **ApiKeyAuthFilterConfig**: invert operators map (operator→key becomes key→operator), fall back to single key mapped to "system" identity
- **ApprovalController**: replace hardcoded `"system"` with operator identity extracted from request attribute, with "system" fallback for safety
- **ControllerIntegrationTestBase**: switch from `str.api.key` to `str.api.operators.ops-lead`, add `authenticatedAs()` / `authenticatedAsJson()` helpers for multi-operator tests
- **ApprovalControllerIntegrationTest**: add 3 tests verifying operator identity propagation (ops-lead approve, compliance-officer approve, compliance-officer cancel) using ArgumentCaptor
- **ApiKeyAuthFilterTest**: rewrite for multi-operator map with 9 tests covering operator identity, fallback, and rejection scenarios
- **ApprovalControllerTest**: update all stubs for operator identity, add fallback-to-system tests for both approve and cancel
- **application-test.yml**: add `str.api.operators` with `ops-lead` and `compliance-officer` entries

## Checklist
- [x] `./gradlew build` passes
- [x] Unit tests added/updated
- [x] Integration tests added/updated
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for multiple operator identities in API authentication. Different API keys can now be assigned to specific operator roles (e.g., ops-lead, compliance-officer).
  * Transaction approvals and cancellations now track and record which operator performed the action, improving audit trails and accountability.

* **Tests**
  * Updated integration and unit tests to validate operator identity propagation across approval and cancellation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->