### PR TITLE
STR-42: add Prometheus alert rules for 8 critical and warning scenarios

### DIFF
--- a/infra/prometheus/alerts.yml
+++ b/infra/prometheus/alerts.yml
@@ -4,7 +4,7 @@ groups:
       - alert: StrTransactionStuckCritical
         expr: >
           histogram_quantile(0.99,
-            rate(str_transaction_stuck_duration_seconds_bucket[5m])
+            sum(rate(str_transaction_stuck_duration_seconds_bucket[5m])) by (le, chain)
           ) > 1800
         for: 5m
         labels:
@@ -50,7 +50,7 @@ groups:
           absent_over_time(str_gas_base_fee_gwei[2m])
           or (changes(str_gas_base_fee_gwei[2m]) == 0
               and str_gas_base_fee_gwei > 0)
-        for: 2m
+        for: 1m
         labels:
           severity: critical
           routing: pagerduty
@@ -67,9 +67,11 @@ groups:
       - alert: StrHighStuckRate
         expr: >
           (
-            rate(str_transactions_stuck_total[5m])
-            / on(chain) rate(str_transactions_submitted_total[5m])
+            sum by (chain) (rate(str_transactions_stuck_total[5m]))
+            /
+            sum by (chain) (rate(str_transactions_submitted_total[5m]))
           ) > 0.2
+          and sum by (chain) (rate(str_transactions_submitted_total[5m])) > 0
         for: 5m
         labels:
           severity: warning
@@ -83,8 +85,11 @@ groups:
 
       - alert: StrGasSpike
         expr: >
-          str_gas_base_fee_gwei
-          / avg_over_time(str_gas_base_fee_gwei[1h]) > 5
+          (
+            str_gas_base_fee_gwei
+            / avg_over_time(str_gas_base_fee_gwei[1h])
+          ) > 5
+          and avg_over_time(str_gas_base_fee_gwei[1h]) > 0
         for: 5m
         labels:
           severity: warning


### PR DESCRIPTION
## STR Issue
Closes #42

## Changes
- Add `infra/prometheus/alerts.yml` with 8 Prometheus alert rules in two groups
- P1 critical alerts (PagerDuty routing): `StrTransactionStuckCritical` (tx stuck >30 min), `StrNonceGapDetected` (nonce gap on any address), `StrRecoveryBudgetExhausted` (gas budget exhausted awaiting human), `StrChainRpcDown` (RPC unreachable >2 min)
- P2 warning alerts (Slack routing): `StrHighStuckRate` (>20% stuck rate), `StrGasSpike` (base fee >5x 1h avg), `StrAddressPoolLow` (<2 active addresses per tier), `StrTemporalWorkflowFailed` (workflow execution failure)
- All alerts reference custom Micrometer metrics from STR-41 with appropriate PromQL expressions
- Each alert includes severity label, routing label, summary annotation, and description annotation

## Checklist
- [x] `./gradlew build` passes
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated (if applicable)
- [x] ArchUnit rules pass
- [x] Spotless formatting applied

🤖 Generated with [Claude Code](https://claude.com/claude-code)