### PR TITLE
STR-46: Makefile: build, test, run, and infrastructure targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,34 @@
+.PHONY: build test integration-test run infra-up infra-down clean format check help
+
+.DEFAULT_GOAL := help
+
+build: ## Run Gradle build (compile + test + spotless check)
+	./gradlew build
+
+test: ## Run unit tests
+	./gradlew test
+
+integration-test: ## Run integration tests with Testcontainers
+	./gradlew integrationTest
+
+run: ## Start the application with development profile
+	./gradlew bootRun --args='--spring.profiles.active=dev'
+
+infra-up: ## Start all infrastructure services via Docker Compose
+	docker compose up -d
+
+infra-down: ## Stop all infrastructure services
+	docker compose down
+
+clean: ## Clean Gradle build output and optionally prune Docker volumes
+	./gradlew clean
+	@echo "Run 'docker volume prune -f' to also remove Docker volumes"
+
+format: ## Auto-format code with Spotless
+	./gradlew spotlessApply
+
+check: ## Run Spotless check and full build
+	./gradlew spotlessCheck build
+
+help: ## Show this help message
+	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'


### PR DESCRIPTION
## Summary
- Add Makefile with 10 standard developer workflow targets
- Includes `build`, `test`, `integration-test`, `run`, `infra-up`, `infra-down`, `clean`, `format`, `check`, and `help`
- All targets have `.PHONY` declarations and `## description` annotations for `make help`

## Test plan
- [ ] `make help` lists all targets with descriptions
- [ ] `make build` runs `./gradlew build`
- [ ] `make test` runs `./gradlew test`
- [ ] `make format` runs `./gradlew spotlessApply`
- [ ] `make check` runs `./gradlew spotlessCheck build`
- [ ] `make infra-up` runs `docker compose up -d`
- [ ] `make infra-down` runs `docker compose down`

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)