### PR TITLE
STR-48: CI/CD GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,151 @@
 name: CI
 
 on:
-  pull_request:
-    branches: [main]
   push:
     branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  JAVA_VERSION: '25'
+  GRADLE_OPTS: >-
+    -Dorg.gradle.daemon=false
+    -Dorg.gradle.parallel=true
+    -Dorg.gradle.caching=true
 
 jobs:
-  build:
+  lint:
+    name: Spotless Check
     runs-on: ubuntu-latest
-
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 25
+          java-version: ${{ env.JAVA_VERSION }}
 
       - uses: gradle/actions/setup-gradle@v4
 
       - run: ./gradlew spotlessCheck
-      - run: ./gradlew build
+
+  unit-test:
+    name: Unit Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew test
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: unit-test-results
+          path: |
+            **/build/reports/tests/test/
+            **/build/test-results/test/
+          retention-days: 14
+
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew integrationTest
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: integration-test-results
+          path: |
+            **/build/reports/tests/integrationTest/
+            **/build/test-results/integrationTest/
+          retention-days: 14
+
+  business-test:
+    name: Business Tests
+    runs-on: ubuntu-latest
+    needs: lint
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew businessTest
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: business-test-results
+          path: |
+            **/build/reports/tests/businessTest/
+            **/build/test-results/businessTest/
+          retention-days: 14
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [unit-test, integration-test, business-test]
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew assemble
+
+  docker:
+    name: Docker Image
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ env.JAVA_VERSION }}
+
+      - uses: gradle/actions/setup-gradle@v4
+
+      - run: ./gradlew :stablebridge-tx-recovery:jibDockerBuild


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` with 6-job pipeline: lint (Spotless), unit/integration/business tests in parallel, build, and Docker image via Jib on main push
- Uses Testcontainers (no GitHub Actions services), Gradle caching, concurrency groups, artifact uploads with 14-day retention
- Java 25 temurin, minimal permissions (`contents: read`)

Closes #48

## Test plan
- [ ] Verify workflow triggers on PR to main
- [ ] Verify lint job runs `spotlessCheck`
- [ ] Verify unit/integration/business test jobs run in parallel after lint
- [ ] Verify test artifacts are uploaded
- [ ] Verify Docker job only runs on main push
- [ ] Verify concurrency cancels redundant PR builds

🤖 Generated with [Claude Code](https://claude.com/claude-code)