### PR TITLE
STR-103: restructure README in prism-inspired narrative style

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,18 +4,20 @@
 ![Java 25](https://img.shields.io/badge/Java-25_LTS-ED8B00?style=for-the-badge&logo=openjdk&logoColor=white)
 ![Spring Boot](https://img.shields.io/badge/Spring_Boot-4.0.3-6DB33F?style=for-the-badge&logo=springboot&logoColor=white)
 ![PostgreSQL](https://img.shields.io/badge/PostgreSQL-16-4169E1?style=for-the-badge&logo=postgresql&logoColor=white)
-![Kafka](https://img.shields.io/badge/Kafka-Redpanda-E0234E?style=for-the-badge&logo=apachekafka&logoColor=white)
-![Temporal](https://img.shields.io/badge/Temporal-1.29-000000?style=for-the-badge&logo=temporal&logoColor=white)
-![Redis](https://img.shields.io/badge/Redis-7.4-DC382D?style=for-the-badge&logo=redis&logoColor=white)
-![Architecture](https://img.shields.io/badge/Architecture-Hexagonal-purple?style=for-the-badge)
+![Temporal](https://img.shields.io/badge/Temporal-Workflows-000000?style=for-the-badge&logo=temporal&logoColor=white)
+![Redis](https://img.shields.io/badge/Redis-Stack_7.4-DC382D?style=for-the-badge&logo=redis&logoColor=white)
+![Redpanda](https://img.shields.io/badge/Redpanda-Kafka_API-E0234E?style=for-the-badge&logo=apachekafka&logoColor=white)
+![Architecture](https://img.shields.io/badge/Architecture-Hexagonal_%2B_DDD-purple?style=for-the-badge)
 ![License](https://img.shields.io/badge/License-MIT-yellow?style=for-the-badge)
 [![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/Puneethkumarck/stablebridge-tx-recovery)
 
-# StableBridge Transaction Recovery
+# StableBridge TX Recovery
 
-**Enterprise-grade microservice for stablecoin transaction recovery across EVM and Solana chains.** Detects stuck or failed on-chain transactions and orchestrates automated recovery with configurable escalation tiers, gas management, and human-approval workflows.
+### Durable transaction lifecycle management for EVM and Solana.
 
-[Why Transaction Recovery?](#why-do-blockchain-transactions-fail) | [Understanding the Chains](#understanding-recovery-across-chains) | [Architecture](#architecture) | [Quick Start](#getting-started) | [API Reference](#api-reference) | [Configuration](#configuration-reference)
+**A Spring Boot 4 microservice that owns a stablecoin transfer from submission to finality — detecting stuck transactions, escalating gas through tiered strategies, routing high-value decisions to humans, and publishing lifecycle events over Kafka. All orchestrated by Temporal workflows that survive crashes.**
+
+[Why this exists?](#-why-this-exists) · [Architecture](#-architecture) · [Transaction Lifecycle](#-the-transaction-lifecycle) · [Escalation Tiers](#-escalation-tiers) · [Quick Start](#-quick-start) · [API](#-api-reference) · [Config](#-configuration-reference)
 
 </div>
 
@@ -23,26 +25,58 @@
 
 ## The Problem
 
-Blockchain transactions fail silently. A submitted stablecoin transfer can get stuck in the mempool for hours — and there's no built-in mechanism to detect this, let alone fix it.
+You submitted a USDC transfer on Ethereum. The RPC node returned a hash. You updated your database. You assumed it confirmed. Three hours later, PagerDuty fires — **47 transactions are stuck behind a nonce gap you didn't know about**, gas has spiked 7×, and someone has to replace all of them by hand.
+
+Blockchains have no built-in notion of "this transfer is your responsibility until it either lands or gives up." Every team that moves stablecoins eventually builds some version of this service. This is ours.
 
 ## The Solution
 
-StableBridge TX Recovery manages the **entire transaction lifecycle** from submission to finality. It detects stuck transactions, applies tiered gas-escalation strategies, and routes high-value decisions to human operators — all orchestrated through crash-proof Temporal workflows.
+```text
+ Client                 str-tx-recovery                   Chain
+ ──────                 ───────────────                   ─────
+
+  POST /api/v1/transactions                   ┌─► Ethereum
+          │                                   │
+          ▼                                   ├─► Base
+  TransactionSubmissionService                │
+          │                                   ├─► Polygon
+          ▼                                   │
+  start Temporal workflow ──► build ──► sign ─┴─► broadcast
+          │                    │        │              │
+          │                    │        │              ▼
+          │                    │        │         PENDING
+          │                    │        │              │
+          │                    │        │       detect STUCK
+          │                    │        │              │
+          │                    │        │       escalate gas
+          │                    │        │         (tiered)
+          │                    │        │              │
+          │                    │        │       CONFIRMED
+          │                    │        │              │
+          │                    │        │         FINALIZED
+          │                    ▼        ▼              ▼
+          └─────────► OutboxEventPersister ──► Kafka (str.tx.events.{chain})
+                                          ▲
+                                          │
+                              OutboxEventRelay (ShedLock-guarded)
+```
+
+Every submission becomes a **durable Temporal workflow** that owns the transaction across its entire lifetime — building, signing, broadcasting, polling, assessing stuck conditions, executing recovery, waiting on humans when required, and publishing the terminal outcome to Kafka via a transactional outbox.
 
 ## The Result
 
-A fully automated, multi-chain transaction lifecycle manager that turns "funds stuck for 6 hours, engineer on-call paged" into "automatic recovery in 10 minutes, zero human intervention for 95% of cases."
-
 <div align="center">
 
-| Metric | Value |
-|--------|-------|
-| **Chains** | EVM (Ethereum, Base, Polygon) + Solana |
-| **Recovery** | Tiered: gas bump → nonce replace → human approval |
-| **Durability** | Temporal workflows survive crashes + restarts |
-| **Delivery** | At-least-once (transactional outbox + Kafka) |
-| **Signing** | Pluggable: local keystore or remote HMAC callback |
-| **Escalation** | Separate tiers for standard vs. high-value (>$50K) |
+| Dimension | What you get |
+|---|---|
+| **Chains** | Ethereum, Base, Polygon (EVM) + Solana — configured out of the box |
+| **Durability** | Temporal workflows survive JVM crashes and restarts (24 h execution, 2 h run, continue-as-new) |
+| **Recovery** | 5-level default tier ladder (1.0× → 1.25× → 2.0× → 3.0× → human) and a 3-level high-value ladder |
+| **Human escalation** | Signal-driven approval/cancel routed to operators for high-value or aggressive escalations |
+| **Delivery** | At-least-once event publish via transactional outbox + ShedLock-coordinated relay |
+| **Signing** | Pluggable: `LocalKeystoreSigner` (secp256k1/Ed25519) or `CallbackSignerAdapter` (HMAC-SHA256 remote HSM/KMS) |
+| **Nonce safety** | Redis-backed allocator with on-chain sync endpoint |
+| **Security** | `X-API-Key` header with constant-time comparison (`MessageDigest.isEqual`) |
 
 </div>
 
@@ -50,49 +84,939 @@ A fully automated, multi-chain transaction lifecycle manager that turns "funds s
 
 ## Table of Contents
 
-- [Why Do Blockchain Transactions Fail?](#why-do-blockchain-transactions-fail)
-  - [The Naive Approach (and Why It Fails)](#the-naive-approach-and-why-it-fails)
-  - [What Transaction Recovery Replaces](#what-transaction-recovery-replaces)
-- [Understanding Recovery Across Chains](#understanding-recovery-across-chains)
-  - [EVM Chains (Ethereum, Base, Polygon)](#evm-chains-ethereum-base-polygon)
-  - [Solana](#solana)
-- [Gas Economics: Why Transactions Get Stuck](#gas-economics-why-transactions-get-stuck)
-  - [EIP-1559 and the Fee Market](#eip-1559-and-the-fee-market)
-  - [Solana Priority Fees](#solana-priority-fees)
-- [Nonce Management: The Hidden Complexity](#nonce-management-the-hidden-complexity)
-- [The Mempool: Where Transactions Wait (and Die)](#the-mempool-where-transactions-wait-and-die)
-- [Escalation: From Automatic to Human](#escalation-from-automatic-to-human)
-- [Durable Execution: Why Temporal?](#durable-execution-why-temporal)
-- [The Transaction Recovery Lifecycle](#the-transaction-recovery-lifecycle)
-- [Key Features](#key-features)
-- [Architecture](#architecture)
-  - [System Architecture](#system-architecture)
-  - [Hexagonal Layer Design](#hexagonal-layer-design)
-  - [Transaction Lifecycle State Machine](#transaction-lifecycle-state-machine)
-  - [Temporal Workflow Orchestration](#temporal-workflow-orchestration)
-  - [Event-Driven Architecture](#event-driven-architecture)
-- [Supported Chains](#supported-chains)
-- [Design Patterns & Principles](#design-patterns--principles)
-- [Tech Stack](#tech-stack)
-- [Module Structure](#module-structure)
-- [Getting Started](#getting-started)
-  - [Prerequisites](#prerequisites)
-  - [Quick Start](#quick-start)
-  - [Make Targets](#make-targets)
-- [API Reference](#api-reference)
-- [Configuration Reference](#configuration-reference)
-- [Resilience & Fault Tolerance](#resilience--fault-tolerance)
-- [Security](#security)
-- [Observability](#observability)
-- [Testing Strategy](#testing-strategy)
-- [CI/CD Pipeline](#cicd-pipeline)
-- [Deployment](#deployment)
-- [Infrastructure](#infrastructure)
-- [License](#license)
+- [Why This Exists](#-why-this-exists)
+- [Architecture](#-architecture)
+- [The Transaction Lifecycle](#-the-transaction-lifecycle)
+- [The Hot Path: Submission to Finality](#-the-hot-path-submission-to-finality)
+- [Temporal Workflow & Activities](#-temporal-workflow--activities)
+- [Escalation Tiers](#-escalation-tiers)
+- [Supported Chains](#-supported-chains)
+- [Signing Strategies](#-signing-strategies)
+- [Event-Driven Delivery: Transactional Outbox](#-event-driven-delivery-transactional-outbox)
+- [Resilience & Fault Tolerance](#-resilience--fault-tolerance)
+- [Tech Stack](#-tech-stack)
+- [Module Structure](#-module-structure)
+- [Quick Start](#-quick-start)
+- [Make Targets](#-make-targets)
+- [API Reference](#-api-reference)
+- [Configuration Reference](#-configuration-reference)
+- [Observability](#-observability)
+- [Testing Strategy](#-testing-strategy)
+- [Local Infrastructure](#-local-infrastructure)
+- [Appendix: Blockchain Recovery Primer](#-appendix-blockchain-recovery-primer)
+  - [Why Do Blockchain Transactions Fail?](#why-do-blockchain-transactions-fail)
+  - [Understanding Recovery Across Chains](#understanding-recovery-across-chains)
+  - [Gas Economics: Why Transactions Get Stuck](#gas-economics-why-transactions-get-stuck)
+  - [Nonce Management: The Hidden Complexity](#nonce-management-the-hidden-complexity)
+  - [The Mempool: Where Transactions Wait (and Die)](#the-mempool-where-transactions-wait-and-die)
+  - [Escalation: From Automatic to Human](#escalation-from-automatic-to-human)
+  - [Durable Execution: Why Temporal?](#durable-execution-why-temporal)
+  - [The Transaction Recovery Lifecycle](#the-transaction-recovery-lifecycle)
+- [License](#-license)
 
 ---
 
-## Why Do Blockchain Transactions Fail?
+## 🤔 Why This Exists
+
+Because every on-chain product eventually has to answer the same questions:
+
+- *"Did my 50 USDC transfer actually land, or is it stuck?"*
+- *"How do I bump the gas without double-spending the nonce?"*
+- *"When gas spikes 7×, should I bump again or wait?"*
+- *"This $200k transfer has been stuck for 10 minutes — who decides what to do?"*
+- *"When it finally confirms, how do I tell downstream services without double-publishing?"*
+
+These questions need **durable state, chain-specific expertise, and a decision policy that doesn't require a human for every case**. Fire-and-forget submission code can't answer any of them.
+
+> **🎯 Design principle:** The happy path is just "submit → workflow → confirmed". Everything else — stuck detection, escalation, approval, cancellation, continue-as-new — is the same workflow reacting to signals and activity results. One workflow per transaction. One state machine. No custom schedulers.
+
+---
+
+## 🏛️ Architecture
+
+Strict **hexagonal architecture (ports & adapters)** with DDD tactical patterns. Dependencies always point inward. Verified at build time by ArchUnit.
+
+```text
+             ┌─────────────────────────────────────────────────────┐
+             │                                                     │
+             │              🎯  application/                        │
+             │   ┌──────────────────────────────────────────┐      │
+             │   │ Controllers (Spring MVC)                 │      │
+             │   │   TransactionController /api/v1/tx       │      │
+             │   │   ApprovalController                     │      │
+             │   │   AddressPoolController /api/v1/addrs    │      │
+             │   │   GasOracleController   /api/v1/gas      │      │
+             │   │   StatusController      /api/v1/status   │      │
+             │   │                                          │      │
+             │   │ Temporal wiring                          │      │
+             │   │   TransactionLifecycleWorkflow(Impl)     │      │
+             │   │   TransactionLifecycleActivities(Impl)   │      │
+             │   │   TemporalWorkflowStarter / Signaler     │      │
+             │   │                                          │      │
+             │   │ Security                                 │      │
+             │   │   ApiKeyAuthFilter (X-API-Key)           │      │
+             │   └──────────────────────────────────────────┘      │
+             │                    │                                │
+             │                    ▼ delegates to                   │
+             │   ┌──────────────────────────────────────────┐      │
+             │   │            🧠 domain/                    │      │
+             │   │                                          │      │
+             │   │ Services                                 │      │
+             │   │   TransactionSubmissionService           │      │
+             │   │   TransactionApprovalService             │      │
+             │   │   AddressPoolService                     │      │
+             │   │   GasOracleQueryService                  │      │
+             │   │   StatusService                          │      │
+             │   │   EscalationPolicyEngine                 │      │
+             │   │                                          │      │
+             │   │ Model                                    │      │
+             │   │   TransactionIntent   TransactionStatus  │      │
+             │   │   PooledAddress       AddressTier        │      │
+             │   │   RecoveryPlan        GasBudgetPolicy    │      │
+             │   │   SubmissionStrategy  StateMachine       │      │
+             │   │                                          │      │
+             │   │ Ports (interfaces implemented by infra)  │      │
+             │   │   ChainTransactionManager                │      │
+             │   │   FeeOracle       TransactionSigner      │      │
+             │   │   NonceManager    FeeCache               │      │
+             │   │   TransactionEventPublisher              │      │
+             │   │   AddressPoolRepository                  │      │
+             │   └──────────────────────────────────────────┘      │
+             │                    ▲                                │
+             │                    │ implements ports               │
+             │   ┌──────────────────────────────────────────┐      │
+             │   │        🔌 infrastructure/                │      │
+             │   │                                          │      │
+             │   │  client/evm/      EvmChainTxManager,     │      │
+             │   │                   EvmFeeOracle,          │      │
+             │   │                   EvmRpcClient, RLP,     │      │
+             │   │                   EvmRecoveryStrategy    │      │
+             │   │                                          │      │
+             │   │  client/solana/   SolanaChainTxManager,  │      │
+             │   │                   SolanaFeeOracle,       │      │
+             │   │                   SolanaRpcClient,       │      │
+             │   │                   SolanaRecoveryStrategy │      │
+             │   │                                          │      │
+             │   │  signer/          LocalKeystoreSigner,   │      │
+             │   │                   CallbackSignerAdapter  │      │
+             │   │                                          │      │
+             │   │  redis/           RedisNonceManager,     │      │
+             │   │                   RedisFeeCache          │      │
+             │   │                                          │      │
+             │   │  db/              JPA repos + entities   │      │
+             │   │  db/outbox/       OutboxEventPersister,  │      │
+             │   │                   OutboxEventReader      │      │
+             │   │  stream/          OutboxEventRelay,      │      │
+             │   │                   Kafka publisher        │      │
+             │   │                                          │      │
+             │   │  health/          Rpc/Redis/Kafka        │      │
+             │   │  metrics/         Micrometer recorders   │      │
+             │   └──────────────────────────────────────────┘      │
+             │                                                     │
+             └─────────────────────────────────────────────────────┘
+
+                  🛡️ ArchUnit enforces layer rules at build time
+```
+
+**Layer rules (enforced by `ArchitectureTest`):**
+
+| Rule | What it stops |
+|---|---|
+| `domain` ⊥ `application` | Domain cannot reach up into controllers or Temporal wiring |
+| `domain` ⊥ `infrastructure` | Domain cannot import JDBC, Redis, Kafka, web3 types |
+| `infrastructure` ⊥ `application` | Outbound adapters cannot call controllers |
+| No `@Autowired` field injection | Constructor injection only (`@RequiredArgsConstructor`) |
+| No `System.out` / `System.err` | Structured logs via `@Slf4j` only |
+
+Break any rule → the build fails.
+
+---
+
+## 🔁 The Transaction Lifecycle
+
+The `TransactionStatus` enum defines **14 states, 3 of them terminal**. This is the exact set declared in [`domain/transaction/model/TransactionStatus.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/domain/transaction/model/TransactionStatus.java).
+
+```text
+                              ┌───── terminal ─────┐
+                              ▼                    ▼
+  RECEIVED                FINALIZED             FAILED
+     │                        ▲                    ▲
+     ▼                        │                    │
+  BUILDING                    │                    │
+     │                        │                    │
+     ▼                        │                    │
+  SIGNING                     │                    │
+     │                        │                    │
+     ▼                        │                    │
+  SUBMITTED ─────► PENDING ───┤
+     │                │       │
+     │                ▼       │
+     │              STUCK ────┤
+     │                │       │
+     │                ▼       │
+     │          RECOVERING ───┤
+     │                │       │
+     │                ▼       │
+     │         AWAITING_HUMAN │
+     │                │       │
+     │                ▼       │
+     │           CANCELLING ──┘
+     │                │
+     │                ▼
+     └──────►   CANCELLED   (terminal)
+
+          CONFIRMED ──► FINALIZED  (once finality-blocks reached)
+          DROPPED (terminal — never landed)
+```
+
+**Terminal states:** `FINALIZED`, `FAILED`, `CANCELLED` — checked by `TransactionStatus.isTerminal()`.
+
+---
+
+## ⚡ The Hot Path: Submission to Finality
+
+The flow below describes what actually happens when a client POSTs to `/api/v1/transactions` — every class name and decision point is taken from the source.
+
+```mermaid
+flowchart TB
+    A["POST /api/v1/transactions<br/><i>X-API-Key header</i>"] --> B["ApiKeyAuthFilter<br/>(constant-time compare)"]
+    B --> C["TransactionController"]
+    C --> D["TransactionSubmissionService"]
+    D --> E["TransactionIntentEntity<br/>(unique intent_id)"]
+    D --> F["TemporalTransactionWorkflowStarter<br/>.startWorkflow(intent)"]
+    F --> G["TransactionLifecycleWorkflow.process()"]
+
+    subgraph Workflow["Temporal workflow — durable, crash-proof"]
+      direction TB
+      G --> H["acquireResource()<br/>pick address from pool +<br/>allocate nonce (Redis)"]
+      H --> I["build()<br/>Evm/SolanaTransactionBuilder"]
+      I --> J["sign()<br/>Local keystore OR callback signer"]
+      J --> K["broadcast()<br/>Evm/SolanaRpcClient"]
+      K --> L["checkStatus()<br/>poll every poll-interval"]
+      L -- still pending --> M["assessStuck()<br/>elapsed vs stuck-threshold-blocks"]
+      M -- not stuck --> L
+      M -- stuck --> N["determineEscalationTier()<br/>default or high-value ladder"]
+      N -- bump --> O["executeRecovery()<br/>RBF with gas-multiplier"]
+      O --> L
+      N -- requires human --> P["AWAITING_HUMAN<br/>@SignalMethod approveRecovery/cancel"]
+      P -- approved --> O
+      P -- cancelled --> Q["cancelOnChain()"]
+      L -- landed --> R["waitForFinality()<br/>finality-blocks"]
+      R --> S["publishEvent(FINALIZED)"]
+    end
+
+    S --> T["OutboxEventPersister<br/>(same TX as projection)"]
+    T --> U["OutboxEventRelay<br/>ShedLock-guarded poller"]
+    U --> V["Kafka: str.tx.events.{chain}"]
+```
+
+**Two concurrency boundaries worth noting:**
+
+| Boundary | How it's protected |
+|---|---|
+| **Nonce allocation** | Redis-backed `RedisNonceManager` allocates via Lua scripts; on-chain truth is re-hydrated through `POST /addresses/{address}/nonces/sync` |
+| **Event publish** | Domain events land in the `outbox_event` table in the *same* JDBC transaction as the state change — the `OutboxEventRelay` publishes them afterwards, and `ShedLock` (table `V14__STR_102_create_shedlock.sql`) prevents duplicate relays across instances |
+
+---
+
+## 🧵 Temporal Workflow & Activities
+
+The workflow interface lives at [`application/workflow/TransactionLifecycleWorkflow.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/workflow/TransactionLifecycleWorkflow.java). The implementation in `TransactionLifecycleWorkflowImpl` drives the state machine and delegates every side-effect to activities.
+
+| Type | Name | Purpose |
+|---|---|---|
+| `@WorkflowMethod` | `process(intent, continueState)` | The main driver — loops through the state machine until terminal |
+| `@SignalMethod` | `approveRecovery(approval)` | Operator unblocks an `AWAITING_HUMAN` state |
+| `@SignalMethod` | `cancelTransaction(cancelRequest)` | Operator requests on-chain cancel |
+| `@QueryMethod` | `getStatus()` | Returns a `TransactionSnapshot` without side effects |
+
+**Activity interface** ([`TransactionLifecycleActivities.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/workflow/TransactionLifecycleActivities.java)) — every boundary-crossing operation is an activity so Temporal can retry, log and checkpoint it:
+
+```
+acquireResource   releaseResource    consumeResource
+build             sign               broadcast
+checkStatus       waitForFinality    getPollInterval
+calculateGasBudget assessStuck       determineEscalationTier
+executeRecovery   cancelOnChain
+publishEvent      recordApproval
+```
+
+**Activity timeouts** are per-profile, taken directly from `application.yml`:
+
+| Profile | `start-to-close-timeout` | `max-attempts` | Initial interval | Backoff |
+|---|---|---|---|---|
+| `default-options` | `PT30S` | 3 | `PT1S` | `2.0` |
+| `signing` | `PT10S` | 2 | `PT1S` | `2.0` |
+| `confirmation` | `PT300S` | 1 | `PT1S` | `2.0` |
+| `recovery-execution` | `PT60S` | 3 | `PT1S` | `2.0` |
+
+**Non-retryable exceptions** (configured in `application.yml` → `str.temporal.non-retryable-exceptions`): `NonRetryableException`, `NonceTooLowException`. Everything else follows the profile's retry policy.
+
+**Continue-as-new:** The workflow carries a `ContinueAsNewState` parameter so it can continue itself when a long-running recovery approaches the 2-hour run timeout without losing event history.
+
+---
+
+## 📐 Escalation Tiers
+
+Escalation is **not** hard-coded — it is loaded from `str.escalation.*` at startup and drives the `determineEscalationTier` activity. Two ladders are configured in [`application.yml`](stablebridge-tx-recovery/src/main/resources/application.yml).
+
+**Default ladder** (transaction value ≤ `high-value-threshold-usd`, default `$50,000`):
+
+| Level | `stuck-threshold` | `gas-multiplier` | Requires human? | Description |
+|---|---|---|---|---|
+| 0 | `PT0S` | `1.0` | No | Initial detection — wait |
+| 1 | `PT1M` | `1.25` | No | First speed-up |
+| 2 | `PT3M` | `2.0` | No | Second speed-up |
+| 3 | `PT10M` | `3.0` | No | Aggressive speed-up |
+| 4 | `PT30M` | `3.0` | **Yes** | Human escalation |
+
+**High-value ladder** (transaction value > `$50,000`) — fewer, more conservative bumps before escalating:
+
+| Level | `stuck-threshold` | `gas-multiplier` | Requires human? | Description |
+|---|---|---|---|---|
+| 0 | `PT0S` | `1.0` | No | Initial detection — wait |
+| 1 | `PT1M` | `1.25` | No | First speed-up |
+| 2 | `PT5M` | `1.25` | **Yes** | Human escalation for high-value |
+
+**Gas budget guardrails** (`str.escalation.gas-budget.*`): spend at most `1%` of transaction value on gas, clamped to `$5 min` / `$500 max`. The `EscalationPolicyEngine` refuses to RBF if the next bump would exceed the budget — at which point the workflow transitions to `AWAITING_HUMAN`.
+
+**Submission strategy** (`str.submission.*`): transactions ≥ `sequential-threshold-usd` ($100,000) use `SubmissionStrategy.SEQUENTIAL`; below that, the service uses `PIPELINED` submission with `max-pipeline-depth: 20`.
+
+---
+
+## ⛓️ Supported Chains
+
+Four chains are preconfigured under `str.chains.*` in `application.yml`. Toggle each with `enabled: true|false`.
+
+| Chain | Family | Chain ID | Finality | Stuck threshold | Poll interval | Max fee cap | Preloaded tokens |
+|---|---|---|---|---|---|---|---|
+| `ethereum_mainnet` | `EVM` | `1` | 12 blocks | 250 blocks | `PT12S` | 200 gwei | USDC, USDT |
+| `base_mainnet` | `EVM` | `8453` | 1 block | 100 blocks | `PT2S` | 5 gwei | USDC |
+| `polygon_mainnet` | `EVM` | `137` | 256 blocks | 500 blocks | `PT2S` | 500 gwei | USDC.e, USDT |
+| `solana_mainnet` | `SOLANA` | — | 31 slots | 150 slots | `400ms` | — | USDC |
+
+Each chain has its own Resilience4j circuit breaker and rate limiter:
+
+```yaml
+rpc:
+  urls: [ ... ]
+  timeout: PT5S
+  max-retries: 3
+  rate-limit-rps: 25
+  rate-limit-burst: 50
+  circuit-breaker:
+    failure-rate-threshold: 50    # percent
+    wait-duration-in-open-state: PT30S
+    sliding-window-size: 10
+```
+
+**EVM adapter** ([`infrastructure/client/evm/`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/evm/)): `EvmChainTransactionManager`, `EvmRpcClient`, `EvmFeeOracle` (EIP-1559), `EvmTransactionBuilder` (RLP-encoded), `EvmRecoveryStrategy` (gas bump RBF), `EvmOnChainNonceProvider`.
+
+**Solana adapter** ([`infrastructure/client/solana/`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/client/solana/)): `SolanaChainTransactionManager`, `SolanaRpcClient`, `SolanaFeeOracle` (prioritization fees), `SolanaTransactionBuilder` (blockhash + compute budget), `SolanaRecoveryStrategy`.
+
+---
+
+## 🔐 Signing Strategies
+
+Two pluggable signer implementations live under [`infrastructure/signer/`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/signer/). The `SignerAutoConfiguration` picks one based on `str.signer.backend`.
+
+```text
+ ┌──────────────────────────┐       ┌──────────────────────────┐
+ │ 🗝️  LocalKeystoreSigner  │       │ 📞 CallbackSignerAdapter │
+ ├──────────────────────────┤       ├──────────────────────────┤
+ │ backend: local           │       │ backend: callback        │
+ │ keystore-path: /etc/...  │       │ POST unsigned tx →       │
+ │ password: ${...}         │       │    remote endpoint       │
+ │                          │       │ HMAC-SHA256 verify       │
+ │ secp256k1 (EVM)          │       │ TLS verify configurable  │
+ │ Ed25519    (Solana)      │       │ Timeout: PT5S default    │
+ │ Bouncy Castle + JCE      │       │ Chain-agnostic           │
+ └──────────────────────────┘       └──────────────────────────┘
+```
+
+| Config property | Local | Callback |
+|---|---|---|
+| `str.signer.backend` | `local` | `callback` |
+| `str.signer.keystore-path` | ✅ | — |
+| `str.signer.password` | ✅ | — |
+| `str.signer.callback.hmac-secret` | — | ✅ |
+| `str.signer.callback.timeout` | — | `PT5S` |
+| `str.signer.callback.tls.verify` | — | `true` |
+
+A helper Gradle task generates signing keypairs for local dev: `make generate-key CHAIN_TYPE=solana` → emits `keys.json`.
+
+---
+
+## 📮 Event-Driven Delivery: Transactional Outbox
+
+The service guarantees **at-least-once delivery** of lifecycle events to Kafka using a classic transactional outbox. No "dual-write" — the outbox row and the domain change land in the same Postgres transaction.
+
+```text
+ ┌──────────────────────────────┐    ┌──────────────────────────────┐
+ │ Workflow activity            │    │ OutboxEventRelay             │
+ │                              │    │                              │
+ │ BEGIN TX                     │    │ ShedLock: at most 1 relay at │
+ │   write transaction_intent   │    │   a time across the cluster  │
+ │   OutboxEventPersister.save()│    │                              │
+ │     → outbox_event (PENDING) │    │ loop:                        │
+ │ COMMIT                       │    │   readBatch(PENDING)         │
+ └──────────────────────────────┘    │   foreach event:             │
+                                     │     KafkaTemplate.send(      │
+                                     │       str.tx.events.{chain}) │
+                                     │     mark PUBLISHED           │
+                                     │   sleep poll-interval        │
+                                     └──────────────────────────────┘
+```
+
+| Concern | Implementation |
+|---|---|
+| Outbox table | `V13__STR_102_create_outbox_event.sql` — status (PENDING/PUBLISHED/FAILED), retry count, topic, partition key, JSON payload |
+| Distributed lock | `V14__STR_102_create_shedlock.sql` — ShedLock table guards the relay so only one instance polls at a time |
+| Enabled chains | `str.kafka.enabled-chains` (default `ethereum_mainnet,solana_mainnet`) |
+| Topic replicas | `str.kafka.topic-replicas` (default `1`) |
+| Topic naming | `str.tx.events.{chain}` |
+
+The in-process publisher (`OutboxTransactionEventPublisher`) implements the domain port `TransactionEventPublisher` — the workflow doesn't know Kafka exists.
+
+---
+
+## 🛡️ Resilience & Fault Tolerance
+
+```text
+┌──────────────────────────────────────────────────────────────┐
+│ Layer             Technology         What it protects        │
+├──────────────────────────────────────────────────────────────┤
+│ Circuit breaker   Resilience4j       Failing RPC endpoints   │
+│                   (per chain)        50% threshold / 30 s    │
+│                                      open / 10-call window   │
+│                                                              │
+│ Rate limiter      Resilience4j       RPC provider throttling │
+│                   (per chain)        25 rps sustained,       │
+│                                      50 rps burst            │
+│                                                              │
+│ Retry + backoff   Temporal activity  Transient activity      │
+│                   retry options      failures (2.0× backoff) │
+│                                                              │
+│ Non-retryable     str.temporal.*     Logic errors & nonce    │
+│                   exception list     mismatches fail fast    │
+│                                                              │
+│ At-least-once     Outbox + ShedLock  Kafka delivery through  │
+│ delivery                             crashes / restarts      │
+│                                                              │
+│ Durable exec      Temporal workflow  JVM restarts, process   │
+│                   (24 h exec, 2 h    crashes, continue-as-   │
+│                   run, cont-as-new)  new on long recoveries  │
+│                                                              │
+│ Nonce consistency RedisNonceManager  Concurrent submissions  │
+│                   + Lua scripts      against the same addr   │
+└──────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 🛠️ Tech Stack
+
+| Component | Choice | Version |
+|---|---|---|
+| **Language** | Java | 25 LTS |
+| **Framework** | Spring Boot | 4.0.3 |
+| **Build** | Gradle + Kotlin DSL + `buildSrc/` convention plugins | — |
+| **Database** | PostgreSQL (Testcontainers in tests) | 16 |
+| **Migrations** | Flyway | V1 → V14 |
+| **Object mapping** | MapStruct | 1.6.3 |
+| **Workflow engine** | Temporal Java SDK | — |
+| **Messaging** | Kafka wire protocol via Redpanda (dev) | 24.3.x |
+| **Cache / nonce state** | Redis Stack | 7.4.0-v8 |
+| **Distributed lock** | ShedLock (outbox relay) | — |
+| **Resilience** | Resilience4j (circuit breaker, rate limiter) | — |
+| **Crypto** | Bouncy Castle (secp256k1, Ed25519) | — |
+| **Metrics** | Micrometer → Prometheus | — |
+| **Container image** | Jib (no Dockerfile) | — |
+| **Architecture tests** | ArchUnit | — |
+| **Logging** | SLF4J + Logback | — |
+| **Testing** | JUnit 5 + Mockito (BDD) + AssertJ + Testcontainers + Awaitility | — |
+
+### Explicitly Not Used
+
+| Avoided | Replacement | Why |
+|---|---|---|
+| `@Autowired` field injection | `@RequiredArgsConstructor` + `private final` | Testable, immutable, no reflection surprises |
+| `System.out` / `println` | `@Slf4j` | Structured logs only |
+| Mockito `when()` / `verify()` | BDD `given()` / `then().should()` | Consistent given/when/then narrative |
+| Generic matchers (`any()`) | Actual values | Tests assert on real data, not "anything" |
+| Comments & Javadoc | Self-documenting code | Enforced by project standards |
+
+---
+
+## 🧱 Module Structure
+
+```text
+stablebridge-tx-recovery/                       ← root (convention plugins only)
+│
+├── buildSrc/                                   ← Gradle convention plugins
+│   └── src/main/kotlin/
+│       ├── stablebridge-tx-recovery.service.gradle.kts   ← applied to main service
+│       └── stablebridge-tx-recovery.library.gradle.kts   ← applied to shared lib
+│
+├── stablebridge-tx-recovery/                   ← main Spring Boot service
+│   └── src/
+│       ├── main/java/com/stablebridge/txrecovery/
+│       │   ├── Application.java                ← @SpringBootApplication
+│       │   ├── application/
+│       │   │   ├── controller/                 ← REST controllers (5)
+│       │   │   ├── workflow/                   ← Temporal workflow + activities
+│       │   │   ├── config/                     ← StrProperties, Temporal/Redis/Kafka config
+│       │   │   └── security/                   ← ApiKeyAuthFilter
+│       │   │
+│       │   ├── domain/                         ← pure — no framework imports
+│       │   │   ├── transaction/                ← TransactionSubmissionService, state machine
+│       │   │   ├── address/                    ← AddressPoolService, AddressTier
+│       │   │   ├── recovery/                   ← EscalationPolicyEngine, GasBudgetPolicy
+│       │   │   ├── status/                     ← StatusService
+│       │   │   └── common/model/               ← StateMachine, StateChangedEvent
+│       │   │
+│       │   └── infrastructure/                 ← outbound adapters
+│       │       ├── client/evm/                 ← EVM JSON-RPC + RLP
+│       │       ├── client/solana/              ← Solana JSON-RPC
+│       │       ├── signer/                     ← local + callback signers
+│       │       ├── redis/                      ← nonce mgr + fee cache
+│       │       ├── db/                         ← JPA repos + outbox
+│       │       ├── stream/                     ← Kafka publisher + outbox relay
+│       │       ├── health/                     ← Rpc / Redis / Kafka health
+│       │       └── metrics/                    ← Micrometer recorders
+│       │
+│       └── main/resources/
+│           ├── application.yml                 ← all str.* properties
+│           ├── application-testnet.yml         ← Sepolia + Solana devnet overrides
+│           ├── db/migration/                   ← Flyway V1 → V14
+│           └── logback-spring.xml
+│
+├── stablebridge-tx-recovery-api/               ← shared DTOs (java-library)
+│   └── src/main/java/com/stablebridge/txrecovery/api/model/
+│       ├── SubmitTransactionRequest / ...Response
+│       ├── SubmitBatchRequest / BatchTransactionResponse
+│       ├── ApproveTransactionRequest / ...Response
+│       ├── CancelTransactionRequest / ...Response
+│       ├── RegisterAddressRequest / AddressResponse
+│       ├── DrainResponse / NonceSyncResponse
+│       ├── GasEstimateResponse / GasHistoryResponse / GasHistoryEntry / GasTierEstimate
+│       ├── ChainStatusSummaryResponse / ChainStatusDetailResponse
+│       ├── TransactionResponse / PagedResponse
+│       ├── ApprovalActionDto / ErrorResponse
+│       └── package-info.java
+│
+├── docs/                                       ← ADR, coding / testing standards,
+│                                                 temporal patterns, live-test results
+├── infra/                                      ← Prometheus + Grafana provisioning,
+│                                                 Terraform (local Docker provider)
+├── postman/str-collection.json                 ← importable API collection
+├── docker-compose.yml                          ← full local stack
+├── Makefile                                    ← developer workflow
+└── CLAUDE.md                                   ← agent instructions
+```
+
+---
+
+## 🚀 Quick Start
+
+### Prerequisites
+
+- **Docker** & **Docker Compose** (PostgreSQL, Redis, Redpanda, Temporal, Prometheus, Grafana)
+- **Java 25** (for local Gradle builds)
+- **Make** (optional — thin wrappers around `./gradlew` and `docker compose`)
+
+### 60-Second Onboarding
+
+```bash
+# 1. Clone
+git clone https://github.com/Puneethkumarck/stablebridge-tx-recovery.git
+cd stablebridge-tx-recovery
+
+# 2. Start the whole stack (infrastructure only)
+make infra-up
+
+# 3. Build and run the service locally
+make run
+
+# 4. Register a signing address and sync its nonce from chain
+make register-address ADDR=0xYourAddress CHAIN=ethereum_mainnet TIER=HOT
+make sync-nonce       ADDR=0xYourAddress CHAIN=ethereum_mainnet
+
+# 5. Submit a transaction
+make submit-tx INTENT=11111111-1111-1111-1111-111111111111 \
+               CHAIN=ethereum_mainnet \
+               TO=0xRecipient \
+               AMOUNT=20 \
+               TOKEN=USDC \
+               DECIMALS=6 \
+               CONTRACT=0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48
+```
+
+Once running, `make` will print the URLs:
+
+```
+App API:           http://localhost:8080/api/v1/status
+Actuator Health:   http://localhost:8081/actuator/health
+Prometheus scrape: http://localhost:8081/actuator/prometheus
+
+Temporal UI:       http://localhost:8088
+Redis Insight:     http://localhost:8001
+Prometheus:        http://localhost:9091
+Grafana:           http://localhost:3000  (admin/admin)
+```
+
+### Run Everything in Docker
+
+```bash
+make up          # builds image via Jib + starts infra + app
+make up-testnet  # same, but with --spring.profiles.active=testnet
+make down        # stops everything
+```
+
+---
+
+## 🎛️ Make Targets
+
+| Target | Description |
+|---|---|
+| `make build` | Compile + Spotless + unit + integration tests |
+| `make test` | Unit tests only |
+| `make integration-test` | Integration tests (requires Docker) |
+| `make format` | Auto-format with Spotless |
+| `make check` | Spotless check + full build |
+| `make run` | Run service with default (mainnet) profile |
+| `make run-testnet` | Run with `application-testnet.yml` |
+| `make infra-up` / `infra-down` / `infra-clean` / `infra-status` / `infra-logs` | Local stack control |
+| `make up` / `up-testnet` / `down` | App + infra in Docker |
+| `make docker-build` | Build image via Jib |
+| `make check-health` / `check-status` / `check-redis` / `check-kafka` / `check-temporal` | Quick operational probes |
+| `make register-address` / `sync-nonce` / `submit-tx` / `generate-key` | Test operations |
+| `make terraform-init` / `terraform-up` / `terraform-down` | Local Terraform provisioning |
+| `make help` | List every target |
+
+---
+
+## 🌐 API Reference
+
+Base URL: `http://localhost:8080`. **Every endpoint requires `X-API-Key` — `ApiKeyAuthFilter` rejects unauthenticated requests with `STR-4010`.**
+
+### Transactions — [`TransactionController.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/transaction/TransactionController.java)
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/transactions` | Submit one `SubmitTransactionRequest` |
+| `POST` | `/api/v1/transactions/batch` | Submit a `SubmitBatchRequest` atomically |
+| `GET`  | `/api/v1/transactions/{transactionId}` | Fetch one by ID |
+| `GET`  | `/api/v1/transactions` | List — query params: `chain`, `status`, `fromAddress`, `toAddress`, `token`, `fromDate`, `toDate`, `page`, `size` |
+
+### Approvals & Cancellations — [`ApprovalController.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/approval/ApprovalController.java)
+
+| Method | Path | Description |
+|---|---|---|
+| `POST` | `/api/v1/transactions/{transactionId}/approve` | Unblocks `AWAITING_HUMAN` — sends `approveRecovery` signal |
+| `POST` | `/api/v1/transactions/{transactionId}/cancel` | Sends `cancelTransaction` signal |
+
+### Address Pool — [`AddressPoolController.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/address/AddressPoolController.java)
+
+| Method | Path | Description |
+|---|---|---|
+| `POST`   | `/api/v1/addresses` | Register address — body: `RegisterAddressRequest` (`HOT` / `PRIORITY` / `COLD` tier) |
+| `GET`    | `/api/v1/addresses?chain=&tier=&status=` | List with filters |
+| `DELETE` | `/api/v1/addresses/{address}?chain=` | Drain (status → `DRAINING`) |
+| `POST`   | `/api/v1/addresses/{address}/nonces/sync?chain=` | Refetch on-chain nonce into Redis |
+
+### Gas Oracle — [`GasOracleController.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/gas/GasOracleController.java)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/gas/{chain}` | Current gas estimates (by urgency: FAST / STANDARD / SLOW) |
+| `GET` | `/api/v1/gas/{chain}/history?hours=24` | Historical gas (1 ≤ hours ≤ 168) |
+
+### Chain Status — [`StatusController.java`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/application/controller/status/StatusController.java)
+
+| Method | Path | Description |
+|---|---|---|
+| `GET` | `/api/v1/status` | Summary list for all configured chains |
+| `GET` | `/api/v1/status/{chain}` | Detail for a specific chain |
+
+### Management (port **8081**)
+
+| Path | Description |
+|---|---|
+| `/actuator/health` | Composite health — includes `RpcHealthIndicator`, `RedisHealthIndicator`, `KafkaHealthIndicator`, `TemporalHealthIndicator`, JDBC |
+| `/actuator/prometheus` | Prometheus scrape endpoint |
+| `/actuator/info` | Build info |
+
+### Error Response
+
+```json
+{
+  "error": "STR-4010",
+  "message": "Unauthorized"
+}
+```
+
+| Prefix | Category |
+|---|---|
+| `STR-400x` | Bad request / validation |
+| `STR-401x` | Authentication |
+| `STR-404x` | Not found |
+| `STR-409x` | Conflict / state violation |
+| `STR-500x` | Internal server error |
+
+---
+
+## ⚙️ Configuration Reference
+
+All custom properties use the `str.*` prefix and are bound via `StrProperties`. Every entry below comes from [`application.yml`](stablebridge-tx-recovery/src/main/resources/application.yml).
+
+<details>
+<summary><b>Signer</b> (<code>str.signer.*</code>)</summary>
+
+| Property | Default | Description |
+|---|---|---|
+| `str.signer.backend` | — | `local` or `callback` |
+| `str.signer.keystore-path` | — | PKCS12/JKS keystore path (local backend) |
+| `str.signer.password` | — | Keystore password |
+| `str.signer.callback.hmac-secret` | — | HMAC-SHA256 verification secret |
+| `str.signer.callback.timeout` | `PT5S` | HTTP callback timeout |
+| `str.signer.callback.tls.verify` | `true` | Verify remote signer TLS certificate |
+
+</details>
+
+<details>
+<summary><b>Kafka</b> (<code>str.kafka.*</code>)</summary>
+
+| Property | Default | Description |
+|---|---|---|
+| `str.kafka.enabled-chains` | `ethereum_mainnet,solana_mainnet` | Comma-separated chain IDs producing events |
+| `str.kafka.topic-replicas` | `1` | Topic replication factor |
+
+Topic naming: `str.tx.events.{chain}`.
+</details>
+
+<details>
+<summary><b>Temporal</b> (<code>str.temporal.*</code>)</summary>
+
+| Property | Default | Description |
+|---|---|---|
+| `str.temporal.target` | `127.0.0.1:7233` | Frontend address |
+| `str.temporal.namespace` | `stablebridge-tx-recovery` | Namespace |
+| `str.temporal.task-queue` | `str-transaction-lifecycle` | Worker task queue |
+| `str.temporal.workflow-execution-timeout` | `PT24H` | Max total execution time |
+| `str.temporal.workflow-run-timeout` | `PT2H` | Max per-run time (before continue-as-new) |
+| `str.temporal.non-retryable-exceptions` | `NonRetryableException`, `NonceTooLowException` | Fail-fast classes |
+| `str.temporal.activity-options.*` | see [workflow section](#-temporal-workflow--activities) | Per-profile activity retry policy |
+
+</details>
+
+<details>
+<summary><b>Escalation</b> (<code>str.escalation.*</code>)</summary>
+
+| Property | Default | Description |
+|---|---|---|
+| `str.escalation.high-value-threshold-usd` | `50000` | Switches to high-value ladder |
+| `str.escalation.gas-budget.percentage` | `0.01` | Gas budget as fraction of tx value |
+| `str.escalation.gas-budget.absolute-min-usd` | `5` | Minimum gas budget |
+| `str.escalation.gas-budget.absolute-max-usd` | `500` | Maximum gas budget |
+| `str.escalation.default-tiers[]` | see table | Default ladder |
+| `str.escalation.high-value-tiers[]` | see table | High-value ladder |
+
+</details>
+
+<details>
+<summary><b>Submission</b> (<code>str.submission.*</code>)</summary>
+
+| Property | Default | Description |
+|---|---|---|
+| `str.submission.sequential-threshold-usd` | `100000` | Above this, use `SEQUENTIAL` strategy |
+| `str.submission.max-pipeline-depth` | `20` | Max in-flight transactions per address in `PIPELINED` mode |
+
+</details>
+
+<details>
+<summary><b>Redis</b> (<code>str.redis.*</code>)</summary>
+
+| Property | Default | Description |
+|---|---|---|
+| `str.redis.host` | `${STR_REDIS_HOST:localhost}` | Redis host |
+| `str.redis.port` | `${STR_REDIS_PORT:6379}` | Redis port |
+
+Used by `RedisNonceManager` (atomic allocation via Lua) and `RedisFeeCache` (per-chain `FeeEstimate` by urgency).
+
+</details>
+
+<details>
+<summary><b>Chains</b> (<code>str.chains.{id}.*</code>)</summary>
+
+| Property | Type | Description |
+|---|---|---|
+| `.enabled` | boolean | Enable/disable chain |
+| `.chain-family` | String | `EVM` or `SOLANA` |
+| `.chain-id` | int | Numeric chain ID (EVM) |
+| `.finality-blocks` | int | Blocks (or slots for Solana) until finalized |
+| `.stuck-threshold-blocks` | int | Blocks elapsed before marking stuck |
+| `.poll-interval` | Duration | Status polling cadence |
+| `.max-fee-cap-gwei` | int | Hard upper bound on gas price (EVM) |
+| `.token-contracts` | List<String> | ERC-20 contract addresses (EVM) |
+| `.token-mints` | List<String> | SPL mint addresses (Solana) |
+| `.rpc.urls` / `.rpc.timeout` / `.rpc.max-retries` | — | RPC endpoints + retries |
+| `.rpc.rate-limit-rps` / `.rpc.rate-limit-burst` | — | Resilience4j rate limiter |
+| `.rpc.circuit-breaker.*` | — | Resilience4j circuit breaker |
+
+</details>
+
+### Environment Variables
+
+| Variable | Description |
+|---|---|
+| `DB_HOST` / `DB_PORT` / `DB_NAME` / `DB_USERNAME` / `DB_PASSWORD` | PostgreSQL connection |
+| `STR_REDIS_HOST` / `STR_REDIS_PORT` | Redis connection |
+| `TEMPORAL_FRONTEND_URL` | Temporal frontend address |
+| `STR_SIGNER_BACKEND` / `STR_SIGNER_KEYSTORE_PATH` / `STR_SIGNER_PASSWORD` | Local signer |
+| `STR_SIGNER_CALLBACK_HMAC_SECRET` | Callback signer |
+| `EVM_ETHEREUM_RPC_URL` / `EVM_BASE_RPC_URL` / `EVM_POLYGON_RPC_URL` | EVM RPC endpoints |
+| `SOLANA_RPC_URL` | Solana RPC endpoint |
+| `STR_API_KEY` | Primary API key accepted by `ApiKeyAuthFilter` |
+
+---
+
+## 📊 Observability
+
+### Metrics (Micrometer → Prometheus)
+
+Every metric name below is registered verbatim by the classes in [`infrastructure/metrics/`](stablebridge-tx-recovery/src/main/java/com/stablebridge/txrecovery/infrastructure/metrics/).
+
+**Transactions** — `TransactionMetrics`:
+
+- `str.transactions.submitted.total` (counter)
+- `str.transactions.confirmed.total` (counter)
+- `str.transactions.stuck.total` (counter)
+- `str.transactions.recovered.total` (counter)
+- `str.transactions.failed.total` (counter)
+- `str.transactions.cancelled.total` (counter)
+- `str.transaction.confirmation.duration.seconds` (timer)
+- `str.transaction.stuck.duration.seconds` (timer)
+
+**Human approvals** — `EscalationMetrics`:
+
+- `str.human.escalation.total` (counter)
+- `str.human.escalation.pending` (gauge)
+- `str.human.response.duration.seconds` (timer)
+
+**Address pool** — `AddressPoolMetrics`:
+
+- `str.address.pool.size` (gauge)
+- `str.address.pool.in.flight` (gauge)
+
+**Nonces** — `NonceMetrics`:
+
+- `str.nonce.allocated.total` (counter)
+- `str.nonce.gaps.detected.total` (counter)
+- `str.nonce.in.flight` (gauge)
+
+**Recovery** — `RecoveryMetrics`:
+
+- `str.recovery.attempts.total` (counter)
+- `str.recovery.gas.spent.total` (counter)
+
+**Gas oracle** — `GasOracleMetrics`:
+
+- `str.gas.base.fee.gwei` (gauge)
+- `str.gas.estimate.gwei` (gauge)
+
+Scrape URL: `http://localhost:8081/actuator/prometheus`. Grafana dashboards provisioned from `infra/grafana/`.
+
+### Health Indicators
+
+| Indicator | Verifies |
+|---|---|
+| `RpcHealthIndicator` | All configured chains reachable |
+| `RedisHealthIndicator` | Redis `PING` succeeds |
+| `KafkaHealthIndicator` | Kafka broker reachable |
+| `TemporalHealthIndicator` | Temporal frontend reachable |
+| (Spring Boot built-ins) | PostgreSQL / disk / liveness / readiness |
+
+Endpoint: `http://localhost:8081/actuator/health` with `show-details: always`.
+
+### Logging
+
+Structured logs via `@Slf4j` + Logback, configured in [`logback-spring.xml`](stablebridge-tx-recovery/src/main/resources/logback-spring.xml). MDC context propagates `transactionId` / `chain` / `intentId` through workflow activities (`MdcContextTest` covers it).
+
+---
+
+## 🧪 Testing Strategy
+
+Three-tier pyramid with strict conventions documented in [`docs/TESTING_STANDARDS.md`](docs/TESTING_STANDARDS.md).
+
+```text
+              ┌────────────────────┐
+              │  Integration Tests │  Spring Boot Test + Testcontainers
+              │  (src/integration- │  @PgTest, @KafkaTest, @RedisTest
+              │   test/)           │  real chains via stub RPC
+              ├────────────────────┤
+              │  Architecture Test │  ArchUnit: hexagonal rules,
+              │  (ArchitectureTest)│  no @Autowired, no System.out
+          ┌───┴────────────────────┴───┐
+          │        Unit Tests          │  JUnit 5 + Mockito BDD + AssertJ
+          │  (src/test/, testFixtures) │  no Spring context
+          └────────────────────────────┘
+```
+
+| Tier | Source set | Framework | Docker? |
+|---|---|---|---|
+| Unit | `src/test/` | JUnit 5, Mockito BDD, AssertJ, Awaitility | No |
+| Architecture | `src/test/` | ArchUnit | No |
+| Integration | `src/integration-test/` | Spring Boot Test + Testcontainers (PostgreSQL, Kafka, Redis) | **Yes** |
+
+**Non-negotiable testing rules:**
+
+- Single-assert: `assertThat(actual).usingRecursiveComparison().isEqualTo(expected)`
+- BDD Mockito only — `given()` / `then().should()`, never `when()` / `verify()`
+- No generic matchers (`any()`, `anyString()`, `eq()`) — use actual values
+- `// given` / `// when` / `// then` comments in every test
+- Fixture builders in `src/testFixtures/` with `SOME_*` constants
+- `@PgTest`, `@KafkaTest`, `@RedisTest` meta-annotations start Testcontainers
+
+```bash
+./gradlew test              # unit + architecture
+./gradlew integrationTest   # integration (requires Docker)
+./gradlew build             # everything + Spotless
+```
+
+---
+
+## 🐳 Local Infrastructure
+
+[`docker-compose.yml`](docker-compose.yml) brings up the full dev stack:
+
+| Service | Image | Port(s) | Purpose |
+|---|---|---|---|
+| PostgreSQL (app) | `postgres:16-alpine` | `5432` | Application database |
+| PostgreSQL (Temporal) | `postgres:16-alpine` | `5433` | Temporal server state |
+| Redis Stack | `redis/redis-stack:7.4.0-v8` | `6379`, `8001` | Nonce manager + fee cache + Insight UI |
+| Redpanda | `redpandadata/redpanda:v24.3.1` | `19092` | Kafka-compatible broker |
+| Temporal | `temporalio/auto-setup` | `7233` | Workflow orchestration |
+| Temporal UI | `temporalio/ui` | `8088` | Workflow visualization |
+| Prometheus | `prom/prometheus` | `9091` | Metrics collection |
+| Grafana | `grafana/grafana` | `3000` | Dashboards (admin/admin) |
+
+```bash
+make infra-up       # start stack
+make infra-status   # show containers
+make infra-logs     # tail logs
+make infra-clean    # stop + delete volumes
+```
+
+A Terraform configuration using the Docker provider lives in `infra/terraform/` for repeatable local provisioning — `make terraform-up` / `terraform-down`.
+
+---
+
+## 📚 Appendix: Blockchain Recovery Primer
+
+> The sections below explain the *why* behind the design — blockchain mechanics, gas economics, nonce races, mempool realities, and Temporal's durable execution model. They are intentionally tutorial-style and partly redundant with the main body above. Skip them if you already know how EIP-1559 and Solana blockhashes work.
+
+### Why Do Blockchain Transactions Fail?
 
 When you submit a transaction to a blockchain, it doesn't execute immediately. It enters a **mempool** — a waiting area where unconfirmed transactions sit until a validator picks them up and includes them in a block. Between submission and confirmation, many things can go wrong:
 
@@ -104,7 +1028,7 @@ When you submit a transaction to a blockchain, it doesn't execute immediately. I
 | 📡 | **RPC node failures** | Node accepted your TX, returned a hash... then silently dropped it | 🔴 Invisible — you think it's fine |
 | 🗑️ | **Mempool eviction** | Mempool is full. Lowest-fee TXs are purged. No error. No notification. Just gone | 🔴 Silent data loss |
 
-### The Naive Approach (and Why It Fails)
+#### The Naive Approach (and Why It Fails)
 
 > **🎬 A Day in the Life of a Stuck Transaction**
 
@@ -145,7 +1069,7 @@ Most applications treat transaction submission as **"fire and forget."** They su
 
 This is error-prone, chain-specific, and doesn't scale. A single stuck transaction can block an entire nonce sequence, cascading into dozens of failed transfers.
 
-### What Transaction Recovery Replaces
+#### What Transaction Recovery Replaces
 
 ```mermaid
 flowchart LR
@@ -162,8 +1086,8 @@ flowchart LR
     subgraph With["✅ With StableBridge TX Recovery"]
         direction TB
         B1["📤 Submit via API"] --> B2["⚙️ Temporal workflow<br/>manages lifecycle"]
-        B2 --> B3["🔍 Detect stuck<br/>after 10 min"]
-        B3 --> B4["⛽ Auto gas bump<br/>(1.2x → 1.5x → 2.0x)"]
+        B2 --> B3["🔍 Detect stuck<br/>at configured threshold"]
+        B3 --> B4["⛽ Auto gas bump<br/>(1.25x → 2.0x → 3.0x)"]
         B4 --> B5["👤 Escalate to human<br/>only if needed"]
         B5 --> B6["✅ Confirmed.<br/>Event published."]
     end
@@ -173,11 +1097,11 @@ flowchart LR
 
 ---
 
-## Understanding Recovery Across Chains
+### Understanding Recovery Across Chains
 
 StableBridge TX Recovery supports two fundamentally different blockchain architectures, each with its own transaction model, gas mechanism, and failure modes. Understanding these differences is essential to understanding why recovery is chain-specific.
 
-### ⟠ EVM Chains (Ethereum, Base, Polygon)
+#### ⟠ EVM Chains (Ethereum, Base, Polygon)
 
 EVM chains use an **account-based model** with sequential nonces and a fee market. Every transaction from an address has a nonce — a counter that starts at 0 and increments by 1 for each transaction.
 
@@ -231,14 +1155,14 @@ When a transaction is stuck, there are exactly two options: **speed it up** (res
  🔢 Nonce:     42                        🔢 Nonce:     42  (same!)
  📬 To:        0xMerchant                📬 To:        0xMerchant
  💰 Value:     50 USDC                   💰 Value:     50 USDC
- ⛽ Gas Price: 20 gwei                   ⛽ Gas Price: 30 gwei  ← 1.5x bump 📈
+ ⛽ Gas Price: 20 gwei                   ⛽ Gas Price: 25 gwei  ← 1.25x bump 📈
  📊 Status:    Pending (45 min) 😰       📊 Status:    Confirmed ✅
 
  💡 The replacement cancels the original — validators always pick the
     higher-paying version of a transaction with the same nonce.
 ```
 
-### ◎ Solana
+#### ◎ Solana
 
 Solana uses a fundamentally different model. There are **no nonces, no mempool in the traditional sense, and no gas price bidding**. Instead, transactions include a **blockhash** that expires after ~60 seconds, and validators prioritize by **compute unit price**.
 
@@ -308,11 +1232,11 @@ Solana recovery is simpler in one way and harder in another. There's no nonce re
 
 ---
 
-## Gas Economics: Why Transactions Get Stuck
+### Gas Economics: Why Transactions Get Stuck
 
 The number one reason transactions get stuck is **gas pricing**. Understanding gas economics is essential to understanding why an automated recovery service exists.
 
-### ⟠ EIP-1559 and the Fee Market
+#### ⟠ EIP-1559 and the Fee Market
 
 Before EIP-1559 (Ethereum's 2021 fee reform), gas pricing was a simple auction: you set a gas price, and validators picked the highest-paying transactions. This led to wild price spikes and overpayment.
 
@@ -367,9 +1291,9 @@ flowchart TB
 | 😱 | **NFT mint spike** | 80 gwei | 40 gwei | 2 gwei | — | ❌ **Stuck!** Base fee > your max |
 | 😅 | **Spike then drop** | 80→20 gwei | 40 gwei | 2 gwei | 22 gwei | ⏳→✅ Confirms after congestion |
 
-**💡 Why gas bumping works:** When the recovery service detects a stuck transaction, it resubmits with the same nonce but a higher `maxFeePerGas` and `maxPriorityFeePerGas`. The gas oracle queries current network conditions and applies a configurable multiplier (1.2x → 1.5x → 2.0x) to ensure the replacement is competitive.
+**💡 Why gas bumping works:** When the recovery service detects a stuck transaction, it resubmits with the same nonce but a higher `maxFeePerGas` and `maxPriorityFeePerGas`. The gas oracle queries current network conditions and applies a configurable multiplier (1.25x → 2.0x → 3.0x) to ensure the replacement is competitive.
 
-### ◎ Solana Priority Fees
+#### ◎ Solana Priority Fees
 
 Solana doesn't have a gas auction in the EVM sense. Instead, each transaction specifies:
 
@@ -390,7 +1314,7 @@ During congestion, validators prioritize transactions with higher compute unit p
 
 ---
 
-## Nonce Management: The Hidden Complexity
+### Nonce Management: The Hidden Complexity
 
 On EVM chains, every transaction from an address must have a sequential nonce. This creates a subtle but critical problem for systems that submit multiple transactions concurrently.
 
@@ -401,22 +1325,22 @@ On EVM chains, every transaction from an address must have a sequential nonce. T
  ───────────                    ───────────
  📖 Read nonce → 42             📖 Read nonce → 42    ← 💥 RACE!
  📤 Submit TX (nonce=42) ✅     📤 Submit TX (nonce=42) ❌ DUPLICATE!
- 
+
  Without atomic nonce allocation, concurrent submissions
  collide on the same nonce. One succeeds, one fails. 💀
 ```
 
 > **✅ How We Solve It: Redis WATCH/MULTI/EXEC (Optimistic Locking)**
 
-The service uses a Redis **hash** with two fields (`allocated` and `confirmed`) plus an **inflight set** to track pending nonces:
+`RedisNonceManager.allocate()` uses a Redis **hash** with two fields (`allocated` and `confirmed`) plus an **inflight set** to track pending nonces, guarded by `WATCH`/`MULTI`/`EXEC`. Confirmation uses a separate Lua script.
 
 ```text
  📦 Redis Data Structures:
- 
+
  🗂️ Hash: str:nonce:{chain}:{address}
     ├── allocated  = 43   (highest nonce handed out)
     └── confirmed  = 41   (highest nonce confirmed on-chain)
- 
+
  📋 Set: str:nonce:inflight:{chain}:{address}
     └── { 42, 43 }        (nonces in-flight, not yet confirmed)
 ```
@@ -424,7 +1348,7 @@ The service uses a Redis **hash** with two fields (`allocated` and `confirmed`) 
 ```text
  🧵 Thread A                         🧵 Thread B
  ───────────                         ───────────
- 👁️ WATCH hash key                   
+ 👁️ WATCH hash key
  📖 Read allocated → 42              👁️ WATCH hash key
  🔒 MULTI: HSET allocated=43,        📖 Read allocated → 42
            SADD inflight 43          🔒 MULTI: HSET allocated=43,
@@ -477,7 +1401,7 @@ When the service restarts (or suspects nonce drift), `syncFromChain` resets both
 
 ```text
  🔄 Nonce Resync Flow:
- 
+
  💀 Service crashes with allocated = 47, confirmed = 44
  🔄 Service restarts
  📡 Call eth_getTransactionCount(0xSigner) → 47 (next expected nonce)
@@ -492,7 +1416,7 @@ Solana doesn't have nonces — each transaction is independent. But it has its o
 
 ---
 
-## The Mempool: Where Transactions Wait (and Die)
+### The Mempool: Where Transactions Wait (and Die)
 
 The mempool is the most misunderstood part of blockchain transaction processing. It's not a single, global queue — it's a **per-node, in-memory staging area** with no durability guarantees.
 
@@ -518,7 +1442,7 @@ The mempool is the most misunderstood part of blockchain transaction processing.
      │
      ├──→ 📡 Gossip to Node B (best-effort, can fail!)
      └──→ 📡 Gossip to Node C (maybe... maybe not)
- 
+
  ❓ You query Node B: "Where's my transaction?"
  🤷 Node B: "Never heard of it."
 ```
@@ -570,7 +1494,7 @@ This is why the recovery service tracks the `DROPPED` state — when a transacti
 
 ---
 
-## Escalation: From Automatic to Human
+### Escalation: From Automatic to Human
 
 Not all stuck transactions are created equal. A 50 USDC transfer stuck for 15 minutes is an annoyance. A $500,000 USDC transfer stuck for 2 hours is a critical incident. The recovery service uses **tiered escalation** with separate policies for standard and high-value transactions.
 
@@ -666,7 +1590,7 @@ flowchart TB
 
 ---
 
-## Durable Execution: Why Temporal?
+### Durable Execution: Why Temporal?
 
 A transaction lifecycle can span minutes to hours. During that time, the recovery service might crash, restart, deploy a new version, or lose network connectivity. The lifecycle must survive all of these.
 
@@ -690,7 +1614,7 @@ A transaction lifecycle can span minutes to hours. During that time, the recover
  ⏱️ T+10 min   🔍 Wake up, check status → STUCK → about to escalate
  ⏱️ T+10.5 min 💥 SERVICE CRASHES
  ⏱️ T+12 min   🔄 New worker picks up EXACTLY where it left off
- ⏱️ T+12 min   ⛽ Escalate: gas bump 1.2x → replacement submitted
+ ⏱️ T+12 min   ⛽ Escalate: gas bump 1.25x → replacement submitted
  ⏱️ T+13 min   ✅ Confirmed. Event published. Zero human intervention.
 ```
 
@@ -735,7 +1659,7 @@ Temporal provides **durable execution** — the workflow code looks like regular
 
 ---
 
-## The Transaction Recovery Lifecycle
+### The Transaction Recovery Lifecycle
 
 The recovery service is one piece of a larger payment infrastructure. Here's where it fits and how a transaction flows through the system end-to-end:
 
@@ -759,7 +1683,7 @@ The recovery service is one piece of a larger payment infrastructure. Here's whe
 >     │  │       │   └─ 🏁 Finalized   │  │
 >     │  │       │       └─ 📢 Event ──┼──┼──► Kafka
 >     │  │       │                      │  │
->     │  │       └─ ⏳ Stuck (>10 min)  │  │
+>     │  │       └─ ⏳ Stuck (>1 min)   │  │
 >     │  │           ├─ 🟢 Auto bump   │  │
 >     │  │           ├─ 🟡 Auto bump   │  │
 >     │  │           └─ 🔴 Human? ─────┼──┼──► 👤 Operator
@@ -796,17 +1720,17 @@ sequenceDiagram
     Chain-->>Temporal: #️⃣ TX hash
 
     Note over Temporal: ⏳ PENDING — poll for confirmation
-    loop 🔍 Every 15 seconds
+    loop 🔍 Every poll-interval
         Temporal->>Chain: eth_getTransactionReceipt
         Chain-->>Temporal: null (still pending)
     end
 
-    Note over Temporal: 🚨 Stuck detection (>10 min pending)
+    Note over Temporal: 🚨 Stuck detection
     Temporal->>Temporal: State → STUCK
 
     Note over Temporal: 🟢 Tier 1: Auto gas bump
     Temporal->>Chain: ⛽ Get current gas price
-    Temporal->>Temporal: 📈 Apply 1.2x multiplier
+    Temporal->>Temporal: 📈 Apply tier multiplier
     Temporal->>Temporal: State → RECOVERING
     Temporal->>Chain: 🔄 Submit replacement (same nonce, higher gas)
 
@@ -817,817 +1741,27 @@ sequenceDiagram
     Temporal->>Kafka: 📢 Publish TransactionFinalizedEvent
     Kafka->>Client: ✅ Event delivered
 
-    Note over Operator: 🔴 (If Tier 3 was reached instead)
-    Temporal-->>Operator: 🚨 State → AWAITING_HUMAN_APPROVAL
+    Note over Operator: 🔴 (If Tier 4 was reached instead)
+    Temporal-->>Operator: 🚨 State → AWAITING_HUMAN
     Operator->>API: 👤 POST /transactions/{id}/approve
     API->>Temporal: 📨 Signal: approveRecovery()
 ```
 
 ---
 
-## Key Features
+## 📜 License
 
-| Category | Capability |
-|----------|-----------|
-| **Multi-Chain Support** | EVM chains (Ethereum, Base, Polygon) + Solana with chain-specific transaction managers |
-| **Automated Recovery** | Tiered escalation: gas bumping, nonce replacement, transaction resubmission |
-| **Human Approval Workflows** | High-value transactions require manual approval via Temporal signals |
-| **Durable Orchestration** | Temporal workflows survive process restarts; 24-hour execution timeout per transaction |
-| **Gas Oracle** | Real-time gas price estimation with EIP-1559 support and historical tracking |
-| **Address Pool Management** | Register, drain, and rotate signer addresses with on-chain nonce synchronization |
-| **Transactional Outbox** | Reliable event publishing via outbox pattern — at-least-once delivery, no dual-write problem |
-| **Batch Submission** | Submit multiple transactions in a single API call with pipeline depth control |
-| **Configurable Escalation** | Separate escalation tiers for standard vs. high-value transactions |
-| **Full Observability** | Prometheus metrics, Grafana dashboards, structured logging, health indicators |
-| **Pluggable Signing** | Local keystore or remote callback signer with HMAC-SHA256 verification |
+Released under the **MIT License**. See [`LICENSE`](LICENSE).
 
 ---
 
-## Architecture
+<div align="center">
 
-### System Architecture
+### StableBridge TX Recovery — Durable transaction lifecycle management for EVM and Solana.
 
-```text
-                                    StableBridge TX Recovery
- ┌──────────────────────────────────────────────────────────────────────────────────────┐
- │                                                                                      │
- │  ┌─────────────────────────────────────────────────────────────────────────────────┐  │
- │  │                          APPLICATION LAYER (Inbound)                            │  │
- │  │                                                                                 │  │
- │  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐  ┌────────────────────┐  │  │
- │  │  │ Transaction  │  │   Approval   │  │  Gas Oracle  │  │  Address Pool      │  │  │
- │  │  │ Controller   │  │  Controller  │  │  Controller  │  │  Controller        │  │  │
- │  │  └──────┬───────┘  └──────┬───────┘  └──────┬───────┘  └────────┬───────────┘  │  │
- │  │         │                 │                  │                   │              │  │
- │  │  ┌──────┴─────────────────┴──────────────────┴───────────────────┘              │  │
- │  │  │                   Temporal Workflow Engine                                   │  │
- │  │  │            TransactionLifecycleWorkflow (Signals + Queries)                  │  │
- │  │  └──────┬──────────────────────────────────────────────────────────             │  │
- │  └─────────┼──────────────────────────────────────────────────────────────────────┘  │
- │            │                                                                         │
- │  ┌─────────┼──────────────────────────────────────────────────────────────────────┐  │
- │  │         ▼                    DOMAIN LAYER (Core)                                │  │
- │  │                                                                                 │  │
- │  │  ┌──────────────────┐  ┌───────────────────┐  ┌─────────────────────────────┐  │  │
- │  │  │  Transaction     │  │  Escalation       │  │  Address Pool               │  │  │
- │  │  │  Submission      │  │  Policy Engine    │  │  Service                    │  │  │
- │  │  │  Service         │  │                   │  │                             │  │  │
- │  │  └────────┬─────────┘  └────────┬──────────┘  └─────────────┬───────────────┘  │  │
- │  │           │                     │                           │                  │  │
- │  │  ┌────────┴─────────────────────┴───────────────────────────┴───────────────┐  │  │
- │  │  │              State Machine  ·  Domain Events  ·  Repository Ports        │  │  │
- │  │  └─────────────────────────────────┬────────────────────────────────────────┘  │  │
- │  └────────────────────────────────────┼───────────────────────────────────────────┘  │
- │                                       │                                              │
- │  ┌────────────────────────────────────┼───────────────────────────────────────────┐  │
- │  │                                    ▼                                            │  │
- │  │                     INFRASTRUCTURE LAYER (Outbound)                             │  │
- │  │                                                                                 │  │
- │  │  ┌──────────┐ ┌──────────┐ ┌───────────┐ ┌─────────┐ ┌────────┐ ┌───────────┐ │  │
- │  │  │PostgreSQL│ │  Kafka   │ │ EVM RPC   │ │ Solana  │ │ Redis  │ │  Signer   │ │  │
- │  │  │ JPA +    │ │ Outbox   │ │ Client    │ │ RPC     │ │ Nonce  │ │ Callback/ │ │  │
- │  │  │ Flyway   │ │ Relay    │ │ (Web3)    │ │ Client  │ │ + Fee  │ │ Keystore  │ │  │
- │  │  └──────────┘ └──────────┘ └───────────┘ └─────────┘ └────────┘ └───────────┘ │  │
- │  └─────────────────────────────────────────────────────────────────────────────────┘  │
- └──────────────────────────────────────────────────────────────────────────────────────┘
+Built on **Java 25 · Spring Boot 4 · Temporal · PostgreSQL 16 · Redis · Kafka**
+Hexagonal · DDD · Event-Driven · At-least-once
 
- External:  Temporal Server  ·  Prometheus / Grafana  ·  Blockchain RPC Nodes
-```
+*Submit once. Survive crashes. Finalize or escalate. Never lose an event.*
 
-### Hexagonal Layer Design
-
-The codebase follows strict **Hexagonal Architecture (Ports & Adapters)** with DDD tactical patterns. Dependencies always point inward:
-
-```text
-┌─────────────────────────────────────────────────────────────────────┐
-│                                                                     │
-│   application/  ──────────►  domain/  ◄──────────  infrastructure/ │
-│   (Inbound Adapters)         (Core)                (Outbound Adapters) │
-│                                                                     │
-│   REST Controllers           Services              PostgreSQL (JPA) │
-│   Temporal Workflows         Aggregates            Kafka (Outbox)   │
-│   Scheduled Jobs             State Machine         EVM RPC Client   │
-│                              Domain Events         Solana RPC Client│
-│   Security Filters           Repository Ports      Redis Adapters   │
-│                              Value Objects          Signer Adapters  │
-│                              Exceptions             MapStruct Mappers│
-│                                                                     │
-└─────────────────────────────────────────────────────────────────────┘
-
-Rules:
-  ✓ Domain layer has ZERO Spring imports (only Lombok)
-  ✓ Domain defines port interfaces — infrastructure implements them
-  ✓ No JPA annotations in domain models
-  ✓ Application layer is thin — delegates to domain services
-  ✓ All mapping via MapStruct at layer boundaries
-```
-
-### Transaction Lifecycle State Machine
-
-Every transaction follows a deterministic, type-safe state machine:
-
-```text
-                              ┌──────────┐
-                              │ RECEIVED │  (API submission accepted)
-                              └────┬─────┘
-                                   │
-                              ┌────▼─────┐
-                              │ BUILDING │  (construct chain-specific tx)
-                              └────┬─────┘
-                                   │
-                              ┌────▼─────┐
-                              │ SIGNING  │  (sign via keystore or callback)
-                              └────┬─────┘
-                                   │
-                              ┌────▼──────┐
-                              │ SUBMITTED │  (broadcast to network)
-                              └────┬──────┘
-                                   │
-                              ┌────▼─────┐
-                         ┌────│ PENDING  │────┐
-                         │    └──────────┘    │
-                         │                    │
-                    ┌────▼────┐          ┌────▼──────┐
-                    │  STUCK  │          │ CONFIRMED │  (included in block)
-                    └────┬────┘          └─────┬─────┘
-                         │                     │
-              ┌──────────┼──────────┐    ┌─────▼──────┐
-              │          │          │    │ FINALIZED  │  (block finality reached)
-        ┌─────▼─────┐ ┌──▼───────┐ │    └────────────┘
-        │RECOVERING │ │AWAITING  │ │         ✓ Terminal
-        │(auto)     │ │ HUMAN    │ │
-        └─────┬─────┘ └────┬─────┘ │
-              │             │       │
-              └──────┬──────┘  ┌────▼──────┐
-                     │         │CANCELLING │
-                     ▼         └─────┬─────┘
-              (back to BUILDING      │
-               or SUBMITTED)    ┌────▼─────┐     ┌────────┐
-                                │CANCELLED │     │ FAILED │
-                                └──────────┘     └────────┘
-                                  ✓ Terminal      ✓ Terminal
-
-              ┌─────────┐
-              │ DROPPED │  (tx disappeared from mempool)
-              └─────────┘
-```
-
-**Escalation Tiers** — configurable per transaction value (defaults from `application.yml`):
-
-| Tier | Trigger | Multiplier | Approval |
-|------|---------|-----------|----------|
-| 0 | Immediate | 1.0x (wait) | Automatic |
-| 1 | Stuck > 1 min | 1.25x gas bump | Automatic |
-| 2 | Stuck > 3 min | 2.0x gas bump | Automatic |
-| 3 | Stuck > 10 min | 3.0x aggressive bump | Automatic |
-| 4 | Stuck > 30 min | 3.0x nonce replacement | **Human required** |
-
-High-value transactions (> $50,000 USD) use a shorter, more conservative schedule — escalating to human review after just 5 minutes.
-
-### Temporal Workflow Orchestration
-
-Long-running transaction lifecycles are modeled as **durable Temporal workflows** that survive crashes, restarts, and deployments:
-
-```text
-┌─────────────────────────── TransactionLifecycleWorkflow ──────────────────────────┐
-│                                                                                    │
-│  ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌──────────┐    ┌─────────────┐  │
-│  │ Acquire  │───►│  Build   │───►│  Sign    │───►│Broadcast │───►│   Poll &    │  │
-│  │ Resource │    │    Tx    │    │    Tx    │    │    Tx    │    │   Confirm   │  │
-│  └──────────┘    └──────────┘    └──────────┘    └──────────┘    └──────┬──────┘  │
-│                                                                         │         │
-│                   ┌─────────────────────────────────────────────────────┤         │
-│                   │                                                     │         │
-│                   ▼                                                     ▼         │
-│           ┌──────────────┐    ┌──────────────────┐            ┌──────────────┐   │
-│           │  Assess if   │    │   Escalate       │            │  Finalized   │   │
-│           │   Stuck      │───►│   (gas bump /    │            │  (publish    │   │
-│           │              │    │    replace)       │            │   event)     │   │
-│           └──────────────┘    └────────┬─────────┘            └──────────────┘   │
-│                                        │                                         │
-│                   ┌────────────────────┤                                         │
-│                   ▼                    ▼                                         │
-│          ┌───────────────┐   ┌─────────────────┐                                │
-│          │ Auto-Recovery │   │ Human Approval  │  ◄── Signal: approveRecovery() │
-│          └───────┬───────┘   └────────┬────────┘                                │
-│                  │                    │           ◄── Signal: cancelTransaction()│
-│                  └────────┬───────────┘                                          │
-│                           ▼                                                      │
-│                    (loop back to Build)              Query: getStatus()          │
-│                                                                                  │
-└──────────────────────────────────────────────────────────────────────────────────┘
-
-  Execution Timeout: 24 hours  ·  Run Timeout: 2 hours  ·  Continue-As-New on timeout
-```
-
-| Activity | Timeout | Max Retries | Backoff |
-|----------|---------|-------------|---------|
-| Default | 30s | 3 | 2.0x exponential |
-| Signing | 10s | 2 | 2.0x exponential |
-| Confirmation | 5 min | 1 (no retry) | - |
-| Recovery Execution | 60s | 3 | 2.0x exponential |
-
-### Event-Driven Architecture
-
-All event publishing uses the **Transactional Outbox Pattern** to guarantee reliable at-least-once delivery with no dual-write problem:
-
-```text
-┌──────────────────────────────────────────────────────────────────────┐
-│                        TRANSACTION (atomic)                          │
-│                                                                      │
-│   ┌─────────────┐         ┌──────────────────┐                      │
-│   │ Domain      │  save   │  Outbox Event    │  schedule             │
-│   │ Aggregate   │────────►│  Table           │─────────┐            │
-│   │ (PostgreSQL)│         │  (PostgreSQL)    │         │            │
-│   └─────────────┘         └──────────────────┘         │            │
-│                                                         │            │
-└─────────────────────────────────────────────────────────┼────────────┘
-                                                          │
-                                              ┌───────────▼──────────┐
-                                              │  Outbox Event Relay  │  (scheduled, ShedLock)
-                                              │  ┌───────────────┐   │
-                                              │  │  Poll outbox   │   │
-                                              │  │  Publish Kafka │   │
-                                              │  │  Mark sent     │   │
-                                              │  └───────────────┘   │
-                                              └───────────┬──────────┘
-                                                          │
-                                              ┌───────────▼──────────┐
-                                              │   Kafka              │
-                                              │                      │
-                                              │  str.tx.events.{chain}│
-                                              │  str.tx.dlq.{chain}  │
-                                              │  (6 partitions,      │
-                                              │   30-day retention)  │
-                                              └──────────────────────┘
-```
-
-**Why transactional outbox?** The classic dual-write problem: if you save to the database and then publish to Kafka, a crash between the two operations means the event is lost. If you publish first and then save, a crash means the database doesn't reflect reality. The outbox pattern solves this by writing both the domain change and the event to the **same database transaction**. A separate relay process reads the outbox table and publishes to Kafka — if it crashes, it simply retries (at-least-once delivery).
-
----
-
-## Supported Chains
-
-| Chain | Family | Chain ID | Finality | Stuck Threshold | Gas Model |
-|-------|--------|----------|----------|-----------------|-----------|
-| Ethereum Mainnet | EVM | 1 | 12 blocks | 250 blocks | EIP-1559 |
-| Base Mainnet | EVM | 8453 | 1 block | 100 blocks | EIP-1559 |
-| Polygon Mainnet | EVM | 137 | 256 blocks | 500 blocks | EIP-1559 |
-| Solana Mainnet | Solana | 0 | 31 slots | 150 slots | Priority fees |
-
-Each chain is independently configurable: RPC endpoints, rate limits, circuit breakers, token contracts/mints, and polling intervals.
-
----
-
-## Design Patterns & Principles
-
-| Pattern | Where | Purpose |
-|---------|-------|---------|
-| **Hexagonal Architecture** | Entire codebase | Isolate domain from infrastructure; swap adapters freely |
-| **Domain-Driven Design** | `domain/` package | Rich domain models, aggregates, value objects, ubiquitous language |
-| **CQRS** | Command handlers + Query services | Separate write (submission, approval) from read (status, listing) paths |
-| **Event-Driven** | Kafka + Outbox | Reliable async event publishing with full audit trail of state changes |
-| **Transactional Outbox** | `OutboxEventRelay` | Atomically persist domain changes + events in a single DB transaction |
-| **State Machine** | `StateMachine<S, T>` | Type-safe, table-driven state transitions with action callbacks |
-| **Durable Execution** | Temporal Workflows | Survive crashes; automatic retries; long-running process orchestration |
-| **Saga / Compensating Tx** | Recovery workflow | Escalation tiers with rollback (cancellation) support |
-| **Repository (Port/Adapter)** | Domain ports + JPA adapters | Domain defines interfaces; infrastructure provides implementations |
-| **Strategy** | `EvmRecoveryStrategy` / `SolanaRecoveryStrategy` | Chain-specific recovery logic behind a common interface |
-| **Circuit Breaker** | Resilience4j on RPC clients | Fail fast when chain RPC is degraded; auto-recover |
-| **Rate Limiter** | Per-chain RPC configuration | Respect RPC provider rate limits |
-| **Pessimistic Locking** | Nonce management | Prevent nonce collision under concurrent transaction submission |
-| **Builder (Lombok)** | All records and DTOs | Immutable construction with `@Builder(toBuilder = true)` |
-| **MapStruct Mapping** | Layer boundaries | Compile-time, type-safe object mapping between layers |
-| **Distributed Locking** | ShedLock | Prevent duplicate outbox relay execution across replicas |
-
----
-
-## Tech Stack
-
-| Component | Technology | Version |
-|-----------|-----------|---------|
-| **Language** | Java (LTS) | 25 |
-| **Framework** | Spring Boot | 4.0.3 |
-| **Build** | Gradle (Kotlin DSL) + Convention Plugins | 8.x |
-| **Database** | PostgreSQL | 16 |
-| **Migrations** | Flyway | Latest |
-| **Messaging** | Apache Kafka (Redpanda in dev) | - |
-| **Workflow Engine** | Temporal | 1.29.4 |
-| **Cache / Nonce Store** | Redis | 7.4 |
-| **Resilience** | Resilience4j | - |
-| **Object Mapping** | MapStruct | 1.6.3 |
-| **Cryptography** | Bouncy Castle | - |
-| **Metrics** | Micrometer + Prometheus + Grafana | - |
-| **Structured Logging** | Logstash Logback Encoder | - |
-| **Containerization** | Jib (eclipse-temurin:25-jre-alpine) | - |
-| **Testing** | JUnit 5 + AssertJ + Testcontainers + WireMock + ArchUnit | - |
-| **Code Quality** | Spotless + Lombok + ArchUnit | - |
-| **IaC** | Terraform | - |
-
----
-
-## Module Structure
-
-```text
-stablebridge-tx-recovery/                      <- Root project
-│
-├── stablebridge-tx-recovery/                  <- Main Spring Boot application
-│   └── src/
-│       ├── main/java/com/stablebridge/txrecovery/
-│       │   ├── application/                   <- Inbound adapters
-│       │   │   ├── config/                    <- Spring configuration, properties
-│       │   │   ├── controller/                <- REST API endpoints
-│       │   │   │   ├── transaction/           <- Transaction CRUD
-│       │   │   │   ├── approval/              <- Human approval endpoints
-│       │   │   │   ├── address/               <- Address pool management
-│       │   │   │   ├── gas/                   <- Gas oracle queries
-│       │   │   │   └── status/                <- Chain health status
-│       │   │   ├── security/                  <- API key authentication
-│       │   │   └── workflow/                  <- Temporal workflow + activities
-│       │   │
-│       │   ├── domain/                        <- Core business logic (framework-free)
-│       │   │   ├── transaction/               <- Transaction aggregate
-│       │   │   │   ├── model/                 <- TransactionIntent, TransactionStatus, etc.
-│       │   │   │   └── event/                 <- TransactionLifecycleEvent
-│       │   │   ├── address/                   <- Address pool aggregate
-│       │   │   ├── recovery/                  <- Escalation engine, gas oracle
-│       │   │   ├── status/                    <- Chain status service
-│       │   │   ├── common/model/              <- Shared value objects, StateMachine
-│       │   │   └── exception/                 <- Domain exceptions
-│       │   │
-│       │   └── infrastructure/                <- Outbound adapters
-│       │       ├── db/                        <- JPA entities, repositories, adapters
-│       │       ├── client/evm/                <- EVM JSON-RPC client + recovery
-│       │       ├── client/solana/             <- Solana JSON-RPC client + recovery
-│       │       ├── redis/                     <- Nonce manager, fee cache
-│       │       ├── signer/                    <- Callback + local keystore signers
-│       │       └── stream/                    <- Kafka outbox publisher + relay
-│       │
-│       ├── main/resources/
-│       │   ├── application.yml                <- Base configuration
-│       │   └── db/migration/                  <- Flyway migrations (V1..V14)
-│       │
-│       ├── test/                              <- Unit tests
-│       ├── testFixtures/                      <- Shared fixtures, stubs, base classes
-│       └── integration-test/                  <- Integration tests (Testcontainers)
-│
-├── stablebridge-tx-recovery-api/              <- Shared API contracts (java-library)
-│   └── src/main/java/.../api/model/           <- DTOs, requests, responses, events
-│
-├── buildSrc/                                  <- Gradle convention plugins
-│   └── src/main/kotlin/
-│       ├── stablebridge-tx-recovery.service.gradle.kts
-│       └── stablebridge-tx-recovery.library.gradle.kts
-│
-├── infra/
-│   ├── terraform/                             <- Infrastructure as Code
-│   ├── prometheus/                            <- Prometheus scrape config
-│   └── grafana/                               <- Grafana dashboard definitions
-│
-├── postman/                                   <- Postman API collection
-├── docker-compose.yml                         <- Full local dev stack
-├── Makefile                                   <- Developer workflow automation
-└── .github/workflows/ci.yml                   <- CI/CD pipeline
-```
-
----
-
-## Getting Started
-
-### Prerequisites
-
-- **Java 25** (LTS)
-- **Docker** & **Docker Compose**
-- **Make** (optional, for convenience targets)
-
-### Quick Start
-
-```bash
-# 1. Clone the repository
-git clone https://github.com/Puneethkumarck/stablebridge-tx-recovery.git
-cd stablebridge-tx-recovery
-
-# 2. Start infrastructure (PostgreSQL, Redis, Kafka, Temporal, Prometheus, Grafana)
-make infra-up
-
-# 3. Build and run the application
-make run
-
-# 4. Register a signer address
-make register-address
-
-# 5. Submit a test transaction
-curl -s -X POST http://localhost:8080/api/v1/transactions \
-  -H "Content-Type: application/json" \
-  -H "X-API-Key: <your-api-key>" \
-  -d '{
-    "chain": "ethereum_mainnet",
-    "fromAddress": "0x...",
-    "toAddress": "0x...",
-    "tokenContract": "0xA0b86991c6218b36c1d19D4a2e9Eb0cE3606eB48",
-    "amount": "1000000"
-  }' | jq
-
-# 6. Check transaction status
-curl -s http://localhost:8080/api/v1/transactions | jq
-```
-
-### Make Targets
-
-| Target | Description |
-|--------|-------------|
-| `make build` | Compile + format + test |
-| `make test` | Unit tests only |
-| `make integration-test` | Integration tests (requires Docker) |
-| `make format` | Auto-format with Spotless |
-| `make check` | Spotless check + full build |
-| `make run` | Run with mainnet profile |
-| `make run-testnet` | Run with testnet (Sepolia, Solana Devnet) |
-| `make up` | Start app + all infrastructure |
-| `make up-testnet` | Start app + infra in testnet mode |
-| `make down` | Stop everything |
-| `make infra-up` | Start only infrastructure services |
-| `make infra-down` | Stop infrastructure |
-| `make infra-clean` | Stop + delete all volumes |
-| `make docker-build` | Build Docker image via Jib |
-| `make check-health` | Health check via actuator |
-| `make check-status` | Get all chain statuses |
-| `make check-kafka` | List Kafka topics |
-| `make check-redis` | List Redis nonce keys |
-| `make register-address` | Register a signer address |
-| `make sync-nonce` | Sync on-chain nonce |
-| `make submit-tx` | Submit a test transaction |
-
----
-
-## API Reference
-
-Base URL: `http://localhost:8080` | Authentication: `X-API-Key` header
-
-### Transactions
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/api/v1/transactions` | Submit a single transaction |
-| `POST` | `/api/v1/transactions/batch` | Submit a batch of transactions |
-| `GET` | `/api/v1/transactions/{id}` | Get transaction by ID |
-| `GET` | `/api/v1/transactions` | List transactions with filters |
-
-**Query parameters for listing:** `chain`, `status`, `fromAddress`, `toAddress`, `token`, `fromDate`, `toDate`, `page` (default 0), `size` (default 20)
-
-### Approvals
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/api/v1/transactions/{id}/approve` | Approve a transaction escalation |
-| `POST` | `/api/v1/transactions/{id}/cancel` | Cancel a transaction |
-
-### Chain Status
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/status` | All chain statuses (RPC health, block height, workflow counts) |
-| `GET` | `/api/v1/status/{chain}` | Detailed status for a specific chain |
-
-### Gas Oracle
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `GET` | `/api/v1/gas/{chain}` | Current gas price estimates |
-| `GET` | `/api/v1/gas/{chain}/history` | Historical gas prices (query: `hours`, default 24, max 168) |
-
-### Address Pool
-
-| Method | Path | Description |
-|--------|------|-------------|
-| `POST` | `/api/v1/addresses` | Register a new signer address |
-| `GET` | `/api/v1/addresses` | List addresses (query: `chain`, `tier`, `status`) |
-| `DELETE` | `/api/v1/addresses/{address}` | Drain an address (query: `chain`) |
-| `POST` | `/api/v1/addresses/{address}/nonces/sync` | Sync nonce from chain |
-
-### Health & Metrics
-
-Management endpoints on port **8081**:
-
-| Path | Description |
-|------|-------------|
-| `/actuator/health` | Liveness + readiness (PostgreSQL, Redis, Kafka, Temporal, per-chain RPC) |
-| `/actuator/prometheus` | Prometheus metrics scrape endpoint |
-| `/actuator/info` | Application info (version, build time) |
-
-### Error Response Format
-
-```json
-{
-  "errorCode": "STR-4041",
-  "message": "Transaction not found",
-  "timestamp": "2026-03-30T12:00:00Z",
-  "path": "/api/v1/transactions/abc123"
-}
-```
-
-| Prefix | Category |
-|--------|----------|
-| `STR-400x` | Bad request / validation |
-| `STR-401x` | Authentication |
-| `STR-404x` | Not found |
-| `STR-409x` | Conflict / state violation |
-| `STR-500x` | Internal server error |
-
----
-
-## Configuration Reference
-
-All custom properties use the `str.*` prefix. Full reference:
-
-<details>
-<summary><b>API Security</b> (<code>str.api.*</code>)</summary>
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `str.api.key` | String | `""` | Global API key |
-| `str.api.operators` | Map | `{}` | Named operator-to-key mappings |
-
-</details>
-
-<details>
-<summary><b>Signer</b> (<code>str.signer.*</code>)</summary>
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `str.signer.backend` | String | - | `callback` or `local` |
-| `str.signer.keystore-path` | String | - | Path to JKS/PKCS12 keystore |
-| `str.signer.password` | String | - | Keystore password |
-| `str.signer.callback.hmac-secret` | String | - | HMAC-SHA256 verification secret |
-| `str.signer.callback.timeout` | Duration | `PT5S` | HTTP callback timeout |
-| `str.signer.callback.tls.verify` | boolean | `true` | TLS certificate verification |
-
-</details>
-
-<details>
-<summary><b>Kafka</b> (<code>str.kafka.*</code>)</summary>
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `str.kafka.enabled-chains` | String | `ethereum_mainnet,solana_mainnet` | Comma-separated chain IDs |
-| `str.kafka.topic-replicas` | int | `1` | Topic replication factor |
-
-Note: Kafka properties are configured directly in `application.yml`, not via `StrProperties`.
-
-</details>
-
-<details>
-<summary><b>Temporal</b> (<code>str.temporal.*</code>)</summary>
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `str.temporal.target` | String | `127.0.0.1:7233` | Frontend address |
-| `str.temporal.namespace` | String | `stablebridge-tx-recovery` | Namespace |
-| `str.temporal.task-queue` | String | `str-transaction-lifecycle` | Worker task queue |
-| `str.temporal.workflow-execution-timeout` | Duration | `PT24H` | Max execution time |
-| `str.temporal.workflow-run-timeout` | Duration | `PT2H` | Max single run time |
-
-Activity profiles: `default-options`, `signing`, `confirmation`, `recovery-execution` — each with `start-to-close-timeout`, `max-attempts`, `initial-interval`, `backoff-coefficient`.
-
-</details>
-
-<details>
-<summary><b>Escalation</b> (<code>str.escalation.*</code>)</summary>
-
-| Property | Type | Default | Description |
-|----------|------|---------|-------------|
-| `str.escalation.high-value-threshold-usd` | BigDecimal | `50000` | High-value threshold |
-| `str.escalation.gas-budget.percentage` | double | `0.01` | Gas budget as % of tx value |
-| `str.escalation.gas-budget.absolute-min-usd` | BigDecimal | `5` | Min gas budget |
-| `str.escalation.gas-budget.absolute-max-usd` | BigDecimal | `500` | Max gas budget |
-
-</details>
-
-<details>
-<summary><b>Chain Configuration</b> (<code>str.chains.{id}.*</code>)</summary>
-
-Per-chain configuration (e.g., `str.chains.ethereum_mainnet`):
-
-| Property | Type | Description |
-|----------|------|-------------|
-| `.enabled` | boolean | Enable/disable chain |
-| `.chain-family` | String | `EVM` or `SOLANA` |
-| `.chain-id` | int | Numeric chain ID |
-| `.finality-blocks` | int | Blocks for finality |
-| `.stuck-threshold-blocks` | int | Blocks before stuck |
-| `.poll-interval` | Duration | Block polling interval |
-| `.max-fee-cap-gwei` | int | Max gas fee cap (EVM) |
-| `.token-contracts` | List | Token addresses (EVM) |
-| `.token-mints` | List | Token mints (Solana) |
-| `.rpc.urls` | List | RPC endpoint URLs |
-| `.rpc.timeout` | Duration | RPC call timeout |
-| `.rpc.max-retries` | int | Max retry attempts |
-| `.rpc.rate-limit-rps` | int | Requests/sec limit |
-| `.rpc.rate-limit-burst` | int | Burst limit |
-| `.rpc.circuit-breaker.*` | Object | Resilience4j config |
-
-</details>
-
----
-
-## Resilience & Fault Tolerance
-
-```text
-┌──────────────────────────────────────────────────────────┐
-│                   Resilience Stack                        │
-│                                                          │
-│  ┌────────────────┐  Per-chain RPC circuit breakers      │
-│  │ Circuit Breaker│  50% failure threshold               │
-│  │ (Resilience4j) │  30s open-state wait                 │
-│  └────────────────┘  10-call sliding window              │
-│                                                          │
-│  ┌────────────────┐  25 req/sec sustained                │
-│  │  Rate Limiter  │  50 req/sec burst                    │
-│  │  (per chain)   │  Prevents RPC provider throttling    │
-│  └────────────────┘                                      │
-│                                                          │
-│  ┌────────────────┐  Temporal automatic retry            │
-│  │ Retry + Backoff│  Exponential backoff (2.0x)          │
-│  │ (Temporal)     │  Non-retryable exception whitelist   │
-│  └────────────────┘                                      │
-│                                                          │
-│  ┌────────────────┐  Kafka producer: acks=all, retries=3 │
-│  │ Idempotent     │  Outbox relay: ShedLock (5 min)      │
-│  │ Delivery       │  At-least-once with deduplication    │
-│  └────────────────┘                                      │
-│                                                          │
-│  ┌────────────────┐  Redis CAS for nonce management      │
-│  │ Pessimistic    │  Prevents nonce collision under      │
-│  │ Locking        │  concurrent submission               │
-│  └────────────────┘                                      │
-│                                                          │
-│  ┌────────────────┐  24h workflow execution timeout       │
-│  │ Durable        │  Continue-As-New on run timeout      │
-│  │ Execution      │  Survives crashes and restarts       │
-│  └────────────────┘                                      │
-└──────────────────────────────────────────────────────────┘
-```
-
----
-
-## Security
-
-| Mechanism | Implementation |
-|-----------|---------------|
-| **API Authentication** | API key via `X-API-Key` header with constant-time comparison (`MessageDigest.isEqual`) |
-| **Operator Identity** | Named operator-to-key mappings for audit trail on approvals |
-| **Callback Signing** | HMAC-SHA256 verification for remote signer callbacks |
-| **TLS** | Configurable TLS verification (TLSv1.3) for signer communication |
-| **Secrets** | All sensitive values via environment variables (never in config files) |
-| **Nonce Protection** | Redis CAS (compare-and-swap) prevents nonce reuse under concurrency |
-
----
-
-## Observability
-
-| Layer | Technology | Details |
-|-------|-----------|---------|
-| **Metrics** | Micrometer + Prometheus | Transaction counts, latencies, gas prices, RPC health — scraped at `:8081/actuator/prometheus` |
-| **Dashboards** | Grafana | Pre-configured dashboards in `infra/grafana/` |
-| **Logging** | SLF4J + Logstash Encoder | Structured JSON logs for log aggregation |
-| **Health** | Spring Boot Actuator | Composite health: PostgreSQL, Redis, Kafka, Temporal, per-chain RPC |
-
-Access Grafana at `http://localhost:3000` (admin/admin) and Prometheus at `http://localhost:9091`.
-
----
-
-## Testing Strategy
-
-Three-tier testing pyramid with strict conventions:
-
-```text
-                    ┌───────────────┐
-                    │  Integration  │  Infrastructure adapters with real deps
-                    │  Tests        │  @PgTest, @KafkaTest (Testcontainers)
-                    ├───────────────┤
-                    │  Architecture │  ArchUnit rules: layer deps, no field
-                    │  Tests        │  injection, no System.out, no generic exceptions
-                ┌───┴───────────────┴───┐
-                │      Unit Tests       │  Domain logic, mappers, services
-                │  Mockito BDD + AssertJ│  No Spring context
-                └───────────────────────┘
-```
-
-| Tier | Source Set | Framework | Docker Required |
-|------|-----------|-----------|-----------------|
-| Unit | `src/test/` | JUnit 5, Mockito (BDD), AssertJ | No |
-| Architecture | `src/test/` | ArchUnit | No |
-| Integration | `src/integration-test/` | Spring Boot Test, Testcontainers | Yes |
-
-**Key conventions:**
-- Single `assertThat().usingRecursiveComparison()` (no field-by-field asserts)
-- BDD Mockito: `given()`/`then()`, never `when()`/`verify()`
-- No generic matchers (`any()`, `anyString()`) — use actual values
-- Test fixtures via `testFixtures` source set with builder pattern
-
-```bash
-./gradlew test                # Unit tests
-./gradlew integrationTest     # Integration tests
-./gradlew build               # All tests + Spotless check
-```
-
----
-
-## CI/CD Pipeline
-
-GitHub Actions workflow (`.github/workflows/ci.yml`):
-
-```text
-  ┌────────┐
-  │  Lint  │  Spotless format check
-  └───┬────┘
-      │
-      ├──────────────┬──────────────┐
-      ▼              ▼              ▼
-┌───────────┐ ┌────────────┐ ┌───────────┐
-│Unit Tests │ │Integration │ │ Business  │    (parallel)
-│           │ │   Tests    │ │   Tests   │
-└─────┬─────┘ └─────┬──────┘ └─────┬─────┘
-      │              │              │
-      └──────────────┼──────────────┘
-                     ▼
-               ┌───────────┐
-               │   Build   │  Assemble distribution
-               └─────┬─────┘
-                     │
-                     ▼
-               ┌───────────┐
-               │  Docker   │  Jib build + push (main branch only)
-               └───────────┘
-```
-
-- **Java:** 25 (Temurin)
-- **Concurrency:** Cancels in-progress runs on same branch
-- **Artifacts:** Test results retained for 14 days
-
----
-
-## Deployment
-
-### Docker Image
-
-Built with Jib (no Dockerfile required):
-
-```bash
-./gradlew jibDockerBuild       # Build to local Docker daemon
-./gradlew jib                  # Build and push to registry
-```
-
-| Property | Value |
-|----------|-------|
-| Image | `stablebridge/tx-recovery` |
-| Base | `eclipse-temurin:25-jre-alpine` |
-| Ports | `8080` (app), `8081` (management) |
-| User | UID `1000` |
-| JVM Flags | `-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0` |
-
-### Environment Variables
-
-| Variable | Description |
-|----------|-------------|
-| `STR_SIGNER_BACKEND` | Signer backend (`callback` or `local`) |
-| `STR_SIGNER_KEYSTORE_PATH` | Keystore file path |
-| `STR_SIGNER_PASSWORD` | Keystore password |
-| `STR_SIGNER_CALLBACK_HMAC_SECRET` | Callback HMAC secret |
-| `TEMPORAL_FRONTEND_URL` | Temporal server address |
-| `STR_REDIS_HOST` / `STR_REDIS_PORT` | Redis connection |
-| `EVM_ETHEREUM_RPC_URL` | Ethereum RPC endpoint |
-| `EVM_BASE_RPC_URL` | Base RPC endpoint |
-| `EVM_POLYGON_RPC_URL` | Polygon RPC endpoint |
-| `SOLANA_RPC_URL` | Solana RPC endpoint |
-
----
-
-## Infrastructure
-
-Local development stack via Docker Compose:
-
-| Service | Image | Port(s) | Purpose |
-|---------|-------|---------|---------|
-| PostgreSQL | `postgres:16-alpine` | 5432 | Application database |
-| PostgreSQL (Temporal) | `postgres:16-alpine` | 5433 | Temporal server database |
-| Redis | `redis/redis-stack:7.4.0-v8` | 6379, 8001 | Nonce management + caching |
-| Redpanda | `redpanda:v24.3.1` | 19092 | Kafka-compatible event streaming |
-| Temporal | `temporalio/auto-setup:1.29.4.1` | 7233 | Workflow orchestration |
-| Temporal UI | `temporalio/ui:2.48.1` | 8088 | Workflow visualization |
-| Prometheus | `prom/prometheus:v3.4.0` | 9091 | Metrics collection |
-| Grafana | `grafana/grafana:11.6.0` | 3000 | Dashboards & alerting |
-
-```bash
-make infra-up       # Start all services
-make infra-down     # Stop all services
-make infra-clean    # Stop + delete volumes
-```
-
-Terraform configuration for cloud deployment is in `infra/terraform/`.
-
----
-
-## License
-
-This project is licensed under the [MIT License](LICENSE).
+</div>


### PR DESCRIPTION
## Summary

- Rewrites the main body of `README.md` around a Problem/Solution/Result narrative inspired by the [Prism](https://github.com/Puneethkumarck/prism) README, grounded entirely in verified code facts (controllers, workflow signals, activity names, escalation ladders, chain configs, metric names, port interfaces).
- Preserves the theoretical deep-dive sections (blockchain mechanics, gas economics, nonce races, mempool, escalation ladders, Temporal durability, end-to-end lifecycle) as an **Appendix: Blockchain Recovery Primer** at the end of the file, with minor numerical corrections so the tier multipliers and enum names match the real `application.yml` and `TransactionStatus.java`.
- Net diff: +1028 / −894 lines.

## Verification notes

Every factual claim in the new main body was cross-checked against the source:

- **14 transaction states** — taken verbatim from `domain/transaction/model/TransactionStatus.java`
- **5 REST controllers + URI templates** — grep'd from `@RequestMapping` / `@*Mapping` annotations
- **Activity method names** — all 16 lifted from `application/workflow/TransactionLifecycleActivities.java`
- **Workflow signals / queries** — `approveRecovery`, `cancelTransaction`, `getStatus` verified in `TransactionLifecycleWorkflow.java`
- **Chain configs** (chain IDs, finality, stuck thresholds, poll intervals, fee caps, token contracts) — pulled from `application.yml`
- **Escalation ladders** (5-tier default + 3-tier high-value, `PT1M`/`PT3M`/`PT10M`/`PT30M`, 1.25x / 2.0x / 3.0x) — from `str.escalation.*`
- **Activity timeouts** (`PT30S` default / `PT10S` signing / `PT300S` confirmation / `PT60S` recovery-execution) — from `str.temporal.activity-options.*`
- **Metric names** — grep'd verbatim from `infrastructure/metrics/*.java` constants
- **Infra stack** (Postgres 16, Redis Stack 7.4.0-v8, Redpanda 24.3.1, Temporal, Prometheus, Grafana) — from `docker-compose.yml`
- **Convention plugin filenames** (`stablebridge-tx-recovery.service.gradle.kts`, `stablebridge-tx-recovery.library.gradle.kts`) — verified from `buildSrc/src/main/kotlin/`
- **Nonce manager behaviour** (WATCH/MULTI/EXEC for `allocate()`, Lua script for `confirm()`) — verified against `RedisNonceManager.java` lines 30-113

## Appendix corrections

The preserved theoretical sections had a few numerical drifts from the real config that are fixed here:

- `1.2x → 1.5x → 2.0x` → `1.25x → 2.0x → 3.0x` to match the default tier ladder
- "Detect stuck after 10 min" → "Detect stuck at configured threshold" (tier 1 fires at `PT1M`)
- "gas bump 1.2x" → "gas bump 1.25x" in the Temporal crash-recovery timeline
- `AWAITING_HUMAN_APPROVAL` → `AWAITING_HUMAN` (the actual enum name)

## Test plan

- [x] Pre-commit hook ran `./gradlew build` (spotless + unit + integration + ArchUnit) — all green
- [ ] Render README on GitHub and eyeball the mermaid diagrams and ASCII art
- [ ] Click through internal anchor links in the Table of Contents
- [ ] Confirm the Appendix links (`#-appendix-blockchain-recovery-primer` etc.) resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)